### PR TITLE
refactor: use argparse to replace getopt

### DIFF
--- a/gitstats/__init__.py
+++ b/gitstats/__init__.py
@@ -1,5 +1,8 @@
+# Copyright (c) 2024-present Xianpeng Shen <xianpeng.shen@gmail.com>.
+# GPLv2 / GPLv3
 import platform
 import time
+from importlib.metadata import version
 
 exectime_internal = 0.0
 exectime_external = 0.0
@@ -39,3 +42,6 @@ def load_config(file_path="gitstats.conf") -> dict:
             for k, v in config_parser["gitstats"].items()
         }
     return config
+
+
+__version__ = version("gitstats")

--- a/gitstats/main.py
+++ b/gitstats/main.py
@@ -11,7 +11,7 @@ import sys
 import time
 import zlib
 from multiprocessing import Pool
-from gitstats import load_config, time_start, exectime_external
+from gitstats import load_config, time_start, exectime_external, __version__
 from gitstats.report_creator import HTMLReportCreator, getkeyssortedbyvaluekey
 from gitstats.utils import (
     getgnuplotversion,
@@ -822,6 +822,13 @@ def get_parser() -> argparse.ArgumentParser:
     """Get the parser for the command line arguments."""
     parser = argparse.ArgumentParser(
         description="Generate statistics for a Git repository.",
+    )
+
+    parser.add_argument(
+        "-v",
+        "--version",
+        action="version",
+        version=f"%(prog)s {__version__}",
     )
 
     # Optional arguments

--- a/gitstats/report_creator.py
+++ b/gitstats/report_creator.py
@@ -1,3 +1,7 @@
+# Copyright (c) 2007-2014 Heikki Hokkanen <hoxu@users.sf.net> & others (see doc/AUTHOR)
+# GPLv2 / GPLv3
+# Copyright (c) 2024-present Xianpeng Shen <xianpeng.shen@gmail.com>.
+# GPLv2 / GPLv3
 import os
 import glob
 import shutil

--- a/gitstats/utils.py
+++ b/gitstats/utils.py
@@ -1,3 +1,7 @@
+# Copyright (c) 2007-2014 Heikki Hokkanen <hoxu@users.sf.net> & others (see doc/AUTHOR)
+# GPLv2 / GPLv3
+# Copyright (c) 2024-present Xianpeng Shen <xianpeng.shen@gmail.com>.
+# GPLv2 / GPLv3
 import os
 import sys
 import time


### PR DESCRIPTION
closes #46 and #54 

* use `argparse` to replace `getopt`
* support `--version`
* add license to other code files