### PR TITLE
fix: the configuration from command line doesn't take effect.

### DIFF
--- a/gitstats/__init__.py
+++ b/gitstats/__init__.py
@@ -26,18 +26,26 @@ DEFAULT_CONFIG = {
 }
 
 
+_config = None
+
+
 def load_config(file_path="gitstats.conf") -> dict:
     """Load configuration from a file, or fall back to defaults."""
     import configparser
     import os
 
-    config = DEFAULT_CONFIG.copy()  # Start with defaults
+    global _config
+
+    if _config is not None:
+        return _config
+
+    _config = DEFAULT_CONFIG.copy()  # Start with defaults
     config_parser = configparser.ConfigParser()
 
     if os.path.exists(file_path):
         config_parser.read(file_path)
-        config = {
+        _config = {
             k: int(v) if v.isdigit() else v
             for k, v in config_parser["gitstats"].items()
         }
-    return config
+    return _config


### PR DESCRIPTION
Previously each call of `load_config()` returned a new `config` dictionary, so that the items from command line didn't take effect for modules other than the `main.py`. Now `load_config()` only loads from the `DEFAULT_CONFIG` and the configuration file for the first time of being called and stores the result in the global `_config` . The subsequent calls will only return the `_object` so that all modules could reference to the same configuration.
