### PR TITLE
Merge author by email

### DIFF
--- a/gitstats/main.py
+++ b/gitstats/main.py
@@ -173,16 +173,18 @@ class GitDataCollector(DataCollector):
             self.author_emails[email] = author
             self.author_name_counts[email] = {author: 1}
             return author
-        
+
         # Track name usage for this email
         if author not in self.author_name_counts[email]:
             self.author_name_counts[email][author] = 0
         self.author_name_counts[email][author] += 1
-        
+
         # Update canonical name to the most frequently used one
-        most_used_name = max(self.author_name_counts[email].items(), key=lambda x: x[1])[0]
+        most_used_name = max(
+            self.author_name_counts[email].items(), key=lambda x: x[1]
+        )[0]
         self.author_emails[email] = most_used_name
-        
+
         return self.author_emails[email]
 
     def collect(self, dir):
@@ -298,10 +300,10 @@ class GitDataCollector(DataCollector):
             author, mail = parts[4].split("<", 1)
             author = author.rstrip()
             mail = mail.rstrip(">")
-            
+
             # Get canonical author name based on email
             author = self.get_canonical_author(author, mail)
-            
+
             domain = "?"
             if mail.find("@") != -1:
                 domain = mail.rsplit("@", 1)[1]
@@ -639,9 +641,9 @@ class GitDataCollector(DataCollector):
                 if pos != -1:
                     try:
                         oldstamp = stamp
-                        stamp_str, author_and_email = line[:pos], line[pos + 1:]
+                        stamp_str, author_and_email = line[:pos], line[pos + 1 :]
                         stamp = int(stamp_str)
-                        
+
                         # Parse "Name <email>" format
                         if "<" in author_and_email and ">" in author_and_email:
                             author, mail = author_and_email.split("<", 1)
@@ -652,7 +654,7 @@ class GitDataCollector(DataCollector):
                         else:
                             # Fallback if no email found (shouldn't happen with new format)
                             author = author_and_email
-                        
+
                         if oldstamp > stamp:
                             # clock skew, keep old timestamp to avoid having ugly graph
                             stamp = oldstamp


### PR DESCRIPTION
I know that there is a .mailmap feature for git that helps you merge commits by the same author with different `email` or `name`. But I'd like to automatically merge authors with the same email address. This PR does that :-)


<!-- readthedocs-preview gitstats start -->
----
📚 Documentation preview 📚: https://gitstats--131.org.readthedocs.build/

<!-- readthedocs-preview gitstats end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Consolidated author identities: commits are now grouped by canonical author derived from email, reducing duplicate contributor entries.
  * Emails are collected with commits to improve author mapping and per-author statistics.
  * Per-author stats (commits, lines added/removed) are initialized and consistently maintained across tag, revision and date views.

* **Improvements**
  * More robust parsing and normalization of author information for consistent reporting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->