### PR TITLE
Add five year summary to main report

### DIFF
--- a/gitstats/report_creator.py
+++ b/gitstats/report_creator.py
@@ -157,7 +157,9 @@ class HTMLReportCreator(ReportCreator):
 
             percentage = 0
             if year_key in data.commits_by_year:
-                max_commits = max(data.commits_by_year.values()) if data.commits_by_year else 1
+                max_commits = (
+                    max(data.commits_by_year.values()) if data.commits_by_year else 1
+                )
                 percentage = float(data.commits_by_year[year_key]) / max_commits
             height = max(1, int(200 * percentage))
             f.write(


### PR DESCRIPTION
I'd like to add a 5 year summary at the top of the main report, besides de 32 weeks report.

<!-- readthedocs-preview gitstats start -->
----
📚 Documentation preview 📚: https://gitstats--132.org.readthedocs.build/

<!-- readthedocs-preview gitstats end -->