### PR TITLE
Fix homepage URL in pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,7 +41,7 @@ gitstats = "gitstats.main:main"
 [project.urls]
 source =  "https://github.com/shenxianpeng/gitstats"
 tracker = "https://github.com/shenxianpeng/gitstats/issues"
-homepage = "https://shenxianpeng.github.io/gitstats/main/index.html"
+homepage = "https://shenxianpeng.github.io/gitstats/index.html"
 documentation = "https://gitstats.readthedocs.io/"
 
 [project.optional-dependencies]


### PR DESCRIPTION
Updated homepage URL in project metadata.

<!-- readthedocs-preview gitstats start -->
----
📚 Documentation preview 📚: https://gitstats--149.org.readthedocs.build/

<!-- readthedocs-preview gitstats end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated project homepage URL in configuration to point to the current documentation location.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->