### PR TITLE
Rename 'dir' parameter to 'repo_dir' to avoid shadowing builtin

### DIFF
--- a/gitstats/main.py
+++ b/gitstats/main.py
@@ -130,10 +130,10 @@ class DataCollector:
 
     ##
     # This should be the main function to extract data from the repository.
-    def collect(self, dir):
-        self.dir = dir
+    def collect(self, repo_dir):
+        self.dir = repo_dir
         if len(conf["project_name"]) == 0:
-            self.project_name = os.path.basename(os.path.abspath(dir))
+            self.project_name = os.path.basename(os.path.abspath(repo_dir))
         else:
             self.project_name = conf["project_name"]
 
@@ -172,8 +172,8 @@ class DataCollector:
 
 
 class GitDataCollector(DataCollector):
-    def collect(self, dir):
-        DataCollector.collect(self, dir)
+    def collect(self, repo_dir):
+        DataCollector.collect(self, repo_dir)
 
         self.total_authors += int(
             get_pipe_output(["git shortlog -s {}".format(get_log_range("HEAD", False)), "wc -l"])


### PR DESCRIPTION
## Summary

Renames the `dir` parameter in `DataCollector.collect()` and `GitDataCollector.collect()` to `repo_dir` to avoid shadowing Python's built-in `dir()` function.

## Changes

- `DataCollector.collect(dir)` → `DataCollector.collect(repo_dir)`
- `GitDataCollector.collect(dir)` → `GitDataCollector.collect(repo_dir)`
- Updated internal usage of `dir` variable to `repo_dir`

Closes #215

<!-- readthedocs-preview gitstats start -->
----
📚 Documentation preview 📚: https://gitstats--219.org.readthedocs.build/

<!-- readthedocs-preview gitstats end -->