### PR TITLE
Correct PyPI classifier from 'Build Tools' to 'Version Control :: Git'

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,7 +26,7 @@ classifiers = [
     "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: 3.13",
     "Programming Language :: Python :: 3.14",
-    "Topic :: Software Development :: Build Tools",
+    "Topic :: Software Development :: Version Control",
     "Operating System :: Microsoft :: Windows",
     "Operating System :: POSIX :: Linux",
     "Operating System :: MacOS",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,7 +26,7 @@ classifiers = [
     "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: 3.13",
     "Programming Language :: Python :: 3.14",
-    "Topic :: Software Development :: Version Control",
+    "Topic :: Software Development :: Version Control :: Git",
     "Operating System :: Microsoft :: Windows",
     "Operating System :: POSIX :: Linux",
     "Operating System :: MacOS",


### PR DESCRIPTION
## Summary

Fixes the incorrect PyPI trove classifier: GitStats is a version control analysis tool, not a build tool.

## Changes

- `"Topic :: Software Development :: Build Tools"` → `"Topic :: Software Development :: Version Control"`

Closes #217 

<!-- readthedocs-preview gitstats start -->
----
📚 Documentation preview 📚: https://gitstats--220.org.readthedocs.build/

<!-- readthedocs-preview gitstats end -->