### PR TITLE
docs: add THIRD_PARTY_NOTICES.md for vendored JS files

### DIFF
--- a/gitstats/THIRD_PARTY_NOTICES.md
+++ b/gitstats/THIRD_PARTY_NOTICES.md
@@ -1,0 +1,21 @@
+# Third-Party Notices
+
+This document lists third-party libraries bundled with GitStats.
+
+## chart.umd.min.js
+
+- **Name**: Chart.js
+- **Version**: 4.4.7
+- **Source**: https://www.jsdelivr.com/package/npm/chart.js
+- **License**: MIT
+- **Usage**: Interactive charts rendered in HTML reports (replaces Gnuplot)
+
+To upgrade: download the UMD build from https://www.jsdelivr.com/package/npm/chart.js and replace this file.
+
+## sortable.js
+
+- **Name**: Sortable Table Script
+- **Author**: Joost de Valk (based on kryogenix.org sorttable)
+- **Source**: http://www.joostdevalk.nl/code/sortable-table/
+- **License**: MIT
+- **Usage**: Client-side table sorting in HTML reports


### PR DESCRIPTION
## Summary

Documents the source, version, and license of bundled third-party JavaScript libraries.

## Changes

- Added `gitstats/THIRD_PARTY_NOTICES.md` documenting:
  - `chart.umd.min.js` — Chart.js 4.4.7 (MIT)
  - `sortable.js` — Joost de Valk sortable table (MIT)

Closes #209

<!-- readthedocs-preview gitstats start -->
----
📚 Documentation preview 📚: https://gitstats--221.org.readthedocs.build/

<!-- readthedocs-preview gitstats end -->