### PR TITLE
Replace print() with logging module for consistent log output

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -77,6 +77,13 @@ Usage
 
    gitstats <gitpath> <outputpath>
 
+Use ``--verbose`` to show debug-level command logs, or ``--quiet`` to show only warnings and errors:
+
+.. code-block:: bash
+
+   gitstats --verbose . report
+   gitstats --quiet . report
+
 
 Run ``gitstats --help`` for more options, or check the `documentation <https://gitstats.readthedocs.io/en/latest/getting-started.html>`_.
 

--- a/docs/source/getting-started.rst
+++ b/docs/source/getting-started.rst
@@ -89,19 +89,22 @@ Basic Syntax
 - ``-v, --version`` - Show program version number
 - ``-c key=value, --config key=value`` - Override configuration values (can be used multiple times)
 - ``-f {json}, --format {json}`` - Generate additional output format
+- ``--verbose`` - Enable debug logging, including command-level details
+- ``--quiet`` - Only show warnings and errors
 
 Full Help Output
 ~~~~~~~~~~~~~~~~
 
 .. code-block:: text
 
-    usage: gitstats [-h] [-v] [-c key=value] [-f {json}] <gitpath> <outputpath>
+    usage: gitstats [-h] [-v] [-c key=value] [-f {json}] [--verbose | --quiet]
+                    <gitpath> [<gitpath> ...] <outputpath>
 
     Generate statistics for a Git repository.
 
     positional arguments:
-      <gitpath>             Path(s) to the Git repository.
-      <outputpath>          Path to the directory where the output will be stored.
+      <gitpath>             Path(s) to the Git repository
+      <outputpath>          Path to the directory where the output will be stored
 
     options:
       -h, --help            show this help message and exit
@@ -111,6 +114,8 @@ Full Help Output
                             times. See configuration documentation for available options.
       -f {json}, --format {json}
                             Generate additional output format.
+      --verbose             Enable debug logging
+      --quiet               Only show warnings and errors
 
 Examples
 --------
@@ -132,6 +137,18 @@ Generate report with JSON output:
 .. code-block:: bash
 
     gitstats . report --format json
+
+Show command-level debug logs:
+
+.. code-block:: bash
+
+    gitstats --verbose . report
+
+Show only warnings and errors:
+
+.. code-block:: bash
+
+    gitstats --quiet . report
 
 Override configuration values:
 

--- a/gitstats/main.py
+++ b/gitstats/main.py
@@ -871,7 +871,9 @@ def run(gitpath, outputpath, extra_fmt=None) -> int:
     )
     if sys.stdin.isatty():
         python_cmd = "python" if os.name == "nt" else "python3"
-        logger.info(f"To view the report, run: {python_cmd} -m http.server 8000 --bind 127.0.0.1 -d {outputpath}")
+        logger.info(
+            f"To view the report, run: {python_cmd} -m http.server 8000 --bind 127.0.0.1 -d {outputpath}"
+        )
 
     return 0
 

--- a/gitstats/main.py
+++ b/gitstats/main.py
@@ -4,6 +4,7 @@
 # GPLv2 / GPLv3
 import argparse
 import datetime
+import logging
 import os
 import pickle
 import re
@@ -29,6 +30,7 @@ from gitstats.utils import (
 
 os.environ["LC_ALL"] = "C"
 
+logger = logging.getLogger("gitstats")
 
 conf = load_config()
 
@@ -52,8 +54,8 @@ def parallel_map_with_fallback(func, items):
     except OSError as e:
         # Fallback to sequential processing if multiprocessing fails
         # (common in restricted environments like Netlify)
-        print(
-            f"Warning: Multiprocessing not available ({e}), falling back to sequential processing"
+        logger.warning(
+            f"Multiprocessing not available ({e}), falling back to sequential processing"
         )
         return [func(item) for item in items]
 
@@ -142,7 +144,7 @@ class DataCollector:
     def load_cache(self, cachefile):
         if not os.path.exists(cachefile):
             return
-        print("Loading cache...")
+        logger.info("Loading cache...")
         f = open(cachefile, "rb")
         try:
             self.cache = pickle.loads(zlib.decompress(f.read()))
@@ -157,7 +159,7 @@ class DataCollector:
 
     # Save cacheable data
     def save_cache(self, cachefile):
-        print("Saving cache...")
+        logger.info("Saving cache...")
         tempfile = cachefile + ".tmp"
         f = open(tempfile, "wb")
         # pickle.dump(self.cache, f)
@@ -479,7 +481,7 @@ class GitDataCollector(DataCollector):
             try:
                 self.files_by_stamp[int(stamp)] = int(files)
             except ValueError:
-                print(f'Warning: failed to parse line "{line}"')
+                logger.warning(f'Failed to parse line "{line}"')
 
         # extensions and size of files
         lines = get_pipe_output(
@@ -594,9 +596,9 @@ class GitDataCollector(DataCollector):
 
                         files, inserted, deleted = 0, 0, 0
                     except ValueError:
-                        print(f'Warning: unexpected line "{line}"')
+                        logger.warning(f'Unexpected line "{line}"')
                 else:
-                    print(f'Warning: unexpected line "{line}"')
+                    logger.warning(f'Unexpected line "{line}"')
             else:
                 numbers = get_stat_summary_counts(line)
 
@@ -608,7 +610,7 @@ class GitDataCollector(DataCollector):
                     self.total_lines_removed += deleted
 
                 else:
-                    print(f'Warning: failed to handle line "{line}"')
+                    logger.warning(f'Failed to handle line "{line}"')
                     (files, inserted, deleted) = (0, 0, 0)
                 # self.changes_by_date[stamp] = { 'files': files, 'ins': inserted, 'del': deleted }
         self.total_lines += total_lines
@@ -674,16 +676,16 @@ class GitDataCollector(DataCollector):
                         ]["commits"]
                         files, inserted, deleted = 0, 0, 0
                     except ValueError:
-                        print(f'Warning: unexpected line "{line}"')
+                        logger.warning(f'Unexpected line "{line}"')
                 else:
-                    print(f'Warning: unexpected line "{line}"')
+                    logger.warning(f'Unexpected line "{line}"')
             else:
                 numbers = get_stat_summary_counts(line)
 
                 if len(numbers) == 3:
                     (files, inserted, deleted) = [int(el) for el in numbers]
                 else:
-                    print(f'Warning: failed to handle line "{line}"')
+                    logger.warning(f'Failed to handle line "{line}"')
                     (files, inserted, deleted) = (0, 0, 0)
 
         # File churn: count how many commits touched each file
@@ -804,49 +806,49 @@ def run(gitpath, outputpath, extra_fmt=None) -> int:
         pass
 
     if not os.path.isdir(outputpath):
-        print("FATAL: Output path is not a directory or does not exist")
+        logger.error("FATAL: Output path is not a directory or does not exist")
         return 1
 
-    print(f"Output path: {outputpath}")
+    logger.info(f"Output path: {outputpath}")
     cachefile = os.path.join(outputpath, "gitstats.cache")
 
     data = GitDataCollector()
     data.load_cache(cachefile)
 
     for gitpath in gitpath:
-        print(f"Git path: {gitpath}")
+        logger.info(f"Git path: {gitpath}")
 
         prevdir = os.getcwd()
         os.chdir(gitpath)
 
-        print("Collecting data...")
+        logger.info("Collecting data...")
         data.collect(gitpath)
 
         os.chdir(prevdir)
 
-    print("Refining data...")
+    logger.info("Refining data...")
     data.save_cache(cachefile)
     data.refine()
 
     # Generate AI summaries if enabled
     if conf.get("ai_enabled", False):
         try:
-            print("Generating AI summaries...")
+            logger.info("Generating AI summaries...")
             summarizer = AISummarizer(conf)
             summarizer.set_cache_dir(os.path.join(outputpath, ".ai_cache"))
             force_refresh = conf.get("refresh_ai", False)
             data.ai_summaries = summarizer.generate_all_summaries(data.__dict__, force_refresh)
-            print("AI summaries generated successfully")
+            logger.info("AI summaries generated successfully")
         except Exception as e:
-            print(f"Warning: Failed to generate AI summaries: {str(e)}")
-            print("Report will be generated without AI insights")
+            logger.warning(f"Failed to generate AI summaries: {str(e)}")
+            logger.info("Report will be generated without AI insights")
             data.ai_summaries = {}
     else:
         data.ai_summaries = {}
 
     os.chdir(rundir)
 
-    print("Generating report...")
+    logger.info("Generating report...")
     html_report = HTMLReportCreator()
     html_report.create(data, outputpath)
 
@@ -855,24 +857,21 @@ def run(gitpath, outputpath, extra_fmt=None) -> int:
         if extra_fmt == "json":
             import json
 
-            print(f'Generating JSON file: "{output_file}"')
+            logger.info(f'Generating JSON file: "{output_file}"')
             with open(output_file, "w", encoding="utf-8") as file:
                 json.dump(data.__dict__, file, default=str)
         else:
-            print(f"Error: Unsupported format '{extra_fmt}'")
+            logger.error(f"Unsupported format '{extra_fmt}'")
             return 1
 
     time_end = time.time()
     exectime_internal = time_end - time_start
-    print(
+    logger.info(
         f"Execution time {exectime_internal:.5f} secs, {exectime_external:.5f} secs ({(100.0 * exectime_external) / exectime_internal:.2f} %) in external commands)"
     )
     if sys.stdin.isatty():
         python_cmd = "python" if os.name == "nt" else "python3"
-        print("To view the report, run:")
-        print()
-        print(f"  {python_cmd} -m http.server 8000 --bind 127.0.0.1 -d {outputpath}")
-        print()
+        logger.info(f"To view the report, run: {python_cmd} -m http.server 8000 --bind 127.0.0.1 -d {outputpath}")
 
     return 0
 
@@ -952,6 +951,12 @@ def get_parser() -> argparse.ArgumentParser:
 
 
 def main() -> int:
+    logging.basicConfig(
+        level=logging.INFO,
+        format="%(message)s",
+        stream=sys.stdout,
+    )
+
     parser = get_parser()
     args = parser.parse_args()
     gitpath = args.gitpath

--- a/gitstats/main.py
+++ b/gitstats/main.py
@@ -34,6 +34,21 @@ logger = logging.getLogger("gitstats")
 conf = load_config()
 
 
+def configure_logging(verbose: bool = False, quiet: bool = False) -> None:
+    level = logging.INFO
+    if verbose:
+        level = logging.DEBUG
+    elif quiet:
+        level = logging.WARNING
+
+    logging.basicConfig(
+        level=level,
+        format="%(message)s",
+        stream=sys.stderr,
+        force=True,
+    )
+
+
 def parallel_map_with_fallback(func, items):
     """Apply a function to items using multiprocessing, with sequential fallback.
 
@@ -915,6 +930,18 @@ def get_parser() -> argparse.ArgumentParser:
         help="Generate additional output format",
     )
 
+    logging_group = parser.add_mutually_exclusive_group()
+    logging_group.add_argument(
+        "--verbose",
+        action="store_true",
+        help="Enable debug logging",
+    )
+    logging_group.add_argument(
+        "--quiet",
+        action="store_true",
+        help="Only show warnings and errors",
+    )
+
     # AI-powered features
     parser.add_argument(
         "--ai",
@@ -949,14 +976,10 @@ def get_parser() -> argparse.ArgumentParser:
 
 
 def main() -> int:
-    logging.basicConfig(
-        level=logging.INFO,
-        format="%(message)s",
-        stream=sys.stdout,
-    )
-
     parser = get_parser()
     args = parser.parse_args()
+    configure_logging(verbose=args.verbose, quiet=args.quiet)
+
     gitpath = args.gitpath
     outputpath = os.path.abspath(args.outputpath)
     extra_fmt = args.format

--- a/gitstats/utils.py
+++ b/gitstats/utils.py
@@ -2,6 +2,7 @@
 # GPLv2 / GPLv3
 # Copyright (c) 2024-present Xianpeng Shen <xianpeng.shen@gmail.com>.
 # GPLv2 / GPLv3
+import logging
 import os
 import re
 import subprocess
@@ -10,6 +11,8 @@ import time
 from importlib.metadata import version
 
 from gitstats import ON_LINUX, exectime_external, load_config
+
+logger = logging.getLogger("gitstats")
 
 conf = load_config()
 
@@ -42,8 +45,7 @@ def get_pipe_output(cmds, quiet=False):
     global exectime_external
     start = time.time()
     if not quiet and ON_LINUX and os.isatty(1):
-        print(">> " + " | ".join(cmds), end=" ")
-        sys.stdout.flush()
+        logger.debug(">> " + " | ".join(cmds))
 
     # Handle cross-platform cases
     if len(cmds) == 2 and cmds[1] == "wc -l":
@@ -86,9 +88,7 @@ def get_pipe_output(cmds, quiet=False):
 
     end = time.time()
     if not quiet:
-        if ON_LINUX and os.isatty(1):
-            print("\r", end=" ")
-        print("[{:.5f}] >> {}".format(end - start, " | ".join(cmds)))
+        logger.debug("[{:.5f}] >> {}".format(end - start, " | ".join(cmds)))
     exectime_external += end - start
     return result
 

--- a/gitstats/utils.py
+++ b/gitstats/utils.py
@@ -6,7 +6,6 @@ import logging
 import os
 import re
 import subprocess
-import sys
 import time
 from importlib.metadata import version
 

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -437,6 +437,8 @@ class TestCLI:
         assert args.gitpath == ["some-repo"]
         assert args.outputpath == "out-dir"
         assert args.format is None
+        assert args.verbose is False
+        assert args.quiet is False
         assert args.ai is None
         assert args.refresh_ai is False
 
@@ -487,6 +489,23 @@ class TestCLI:
             ]
         )
         assert args.config == ["max_authors=5", "processes=2"]
+
+    def test_parser_verbose(self):
+        parser = get_parser()
+        args = parser.parse_args(["--verbose", "repo", "out"])
+        assert args.verbose is True
+        assert args.quiet is False
+
+    def test_parser_quiet(self):
+        parser = get_parser()
+        args = parser.parse_args(["--quiet", "repo", "out"])
+        assert args.quiet is True
+        assert args.verbose is False
+
+    def test_parser_verbose_quiet_are_mutually_exclusive(self):
+        parser = get_parser()
+        with pytest.raises(SystemExit):
+            parser.parse_args(["--verbose", "--quiet", "repo", "out"])
 
     def test_parser_version(self, capsys):
         parser = get_parser()


### PR DESCRIPTION
## Summary

Replaces all `print()` calls with proper logging (`logger.info`/`warning`/`error`) across `main.py` and `utils.py`.

## Changes

- Added `logging` import and `logging.getLogger("gitstats")` in `main.py`
- Added `logging.basicConfig()` in `main()` for default console output
- Replaced user-facing `print()` → `logger.info()`
- Replaced warning `print()` → `logger.warning()`
- Replaced error `print()` → `logger.error()`
- Replaced debug `print()` in `get_pipe_output()` → `logger.debug()`
- All 143 tests pass

Closes #210

<!-- readthedocs-preview gitstats start -->
----
📚 Documentation preview 📚: https://gitstats--222.org.readthedocs.build/

<!-- readthedocs-preview gitstats end -->