### PR TITLE
Add type annotations to core modules

### DIFF
--- a/gitstats/__init__.py
+++ b/gitstats/__init__.py
@@ -1,14 +1,16 @@
 # Copyright (c) 2024-present Xianpeng Shen <xianpeng.shen@gmail.com>.
 # GPLv2 / GPLv3
+from __future__ import annotations
+
 import platform
 import time
 
-exectime_internal = 0.0
-exectime_external = 0.0
-time_start = time.time()
+exectime_internal: float = 0.0
+exectime_external: float = 0.0
+time_start: float = time.time()
 
-ON_LINUX = platform.system() == "Linux"
-WEEKDAYS = ("Mon", "Tue", "Wed", "Thu", "Fri", "Sat", "Sun")
+ON_LINUX: bool = platform.system() == "Linux"
+WEEKDAYS: tuple[str, ...] = ("Mon", "Tue", "Wed", "Thu", "Fri", "Sat", "Sun")
 
 DEFAULT_CONFIG = {
     "max_domains": 10,  # Maximum number of domains to display in "Domains by Commits".
@@ -38,7 +40,7 @@ DEFAULT_CONFIG = {
 }
 
 
-_config = None
+_config: dict[str, int | str | bool] | None = None
 
 
 # Internationalization translations for AI Insights page
@@ -172,7 +174,7 @@ def get_i18n_text(key: str, language: str = "en") -> str:
     return translations.get(key, AI_INSIGHTS_I18N["en"].get(key, key))
 
 
-def load_config(file_path="gitstats.conf") -> dict:
+def load_config(file_path: str = "gitstats.conf") -> dict[str, int | str | bool]:
     """Load configuration from a file, or fall back to defaults."""
     import configparser
     import os

--- a/gitstats/main.py
+++ b/gitstats/main.py
@@ -61,7 +61,7 @@ def parallel_map_with_fallback(func, items):
 class DataCollector:
     """Manages data collection from a revision control repository."""
 
-    def __init__(self):
+    def __init__(self) -> None:
         self.stamp_created = time.time()
         self.cache = {}
         self.total_authors = 0
@@ -130,16 +130,16 @@ class DataCollector:
 
     ##
     # This should be the main function to extract data from the repository.
-    def collect(self, dir):
-        self.dir = dir
+    def collect(self, repo_dir: str) -> None:
+        self.dir = repo_dir
         if len(conf["project_name"]) == 0:
-            self.project_name = os.path.basename(os.path.abspath(dir))
+            self.project_name = os.path.basename(os.path.abspath(repo_dir))
         else:
             self.project_name = conf["project_name"]
 
     ##
     # Load cacheable data
-    def load_cache(self, cachefile):
+    def load_cache(self, cachefile: str) -> None:
         if not os.path.exists(cachefile):
             return
         print("Loading cache...")
@@ -152,11 +152,11 @@ class DataCollector:
             self.cache = pickle.load(f)
         f.close()
 
-    def get_stamp_created(self):
+    def get_stamp_created(self) -> float:
         return self.stamp_created
 
     # Save cacheable data
-    def save_cache(self, cachefile):
+    def save_cache(self, cachefile: str) -> None:
         print("Saving cache...")
         tempfile = cachefile + ".tmp"
         f = open(tempfile, "wb")
@@ -172,8 +172,8 @@ class DataCollector:
 
 
 class GitDataCollector(DataCollector):
-    def collect(self, dir):
-        DataCollector.collect(self, dir)
+    def collect(self, repo_dir: str) -> None:
+        DataCollector.collect(self, repo_dir)
 
         self.total_authors += int(
             get_pipe_output(["git shortlog -s {}".format(get_log_range("HEAD", False)), "wc -l"])
@@ -695,7 +695,7 @@ class GitDataCollector(DataCollector):
             if line:
                 self.file_churn[line] = self.file_churn.get(line, 0) + 1
 
-    def refine(self):
+    def refine(self) -> None:
         # authors
         # name -> {place_by_commits, commits_frac, date_first, date_last, timedelta}
         self.authors_by_commits = get_keys_sorted_by_value_key(self.authors, "commits")
@@ -728,61 +728,61 @@ class GitDataCollector(DataCollector):
                     self.new_contributors_by_month.get(first_month, 0) + 1
                 )
 
-    def get_active_days(self):
+    def get_active_days(self) -> set[str]:
         return self.active_days
 
-    def get_activity_by_day_of_week(self):
+    def get_activity_by_day_of_week(self) -> dict[int, int]:
         return self.activity_by_day_of_week
 
-    def get_activity_by_hour_of_day(self):
+    def get_activity_by_hour_of_day(self) -> dict[int, int]:
         return self.activity_by_hour_of_day
 
-    def get_author_info(self, author):
+    def get_author_info(self, author: str) -> dict[str, Any]:
         return self.authors[author]
 
-    def get_authors(self, limit=None):
+    def get_authors(self, limit: int | None = None) -> list[str]:
         res = get_keys_sorted_by_value_key(self.authors, "commits")
         res.reverse()
         return res[:limit]
 
-    def get_commit_delta_days(self):
+    def get_commit_delta_days(self) -> float:
         return (self.last_commit_stamp / 86400 - self.first_commit_stamp / 86400) + 1
 
-    def get_domain_info(self, domain):
+    def get_domain_info(self, domain: str) -> dict[str, int]:
         return self.domains[domain]
 
-    def get_domains(self):
+    def get_domains(self) -> list[str]:
         return list(self.domains.keys())
 
-    def get_first_commit_date(self):
+    def get_first_commit_date(self) -> datetime.datetime:
         return datetime.datetime.fromtimestamp(self.first_commit_stamp)
 
-    def get_last_commit_date(self):
+    def get_last_commit_date(self) -> datetime.datetime:
         return datetime.datetime.fromtimestamp(self.last_commit_stamp)
 
-    def get_tags(self):
+    def get_tags(self) -> list[str]:
         lines = get_pipe_output(["git show-ref --tags", "cut -d/ -f3"])
         return lines.split("\n")
 
-    def get_tag_date(self, tag):
+    def get_tag_date(self, tag: str) -> str:
         return self.rev_to_date("tags/" + tag)
 
-    def get_total_authors(self):
+    def get_total_authors(self) -> int:
         return self.total_authors
 
-    def get_total_commits(self):
+    def get_total_commits(self) -> int:
         return self.total_commits
 
-    def get_total_files(self):
+    def get_total_files(self) -> int:
         return self.total_files
 
-    def get_total_loc(self):
+    def get_total_loc(self) -> int:
         return self.total_lines
 
-    def get_total_size(self):
+    def get_total_size(self) -> int:
         return self.total_size
 
-    def rev_to_date(self, rev):
+    def rev_to_date(self, rev: str) -> str:
         stamp = int(get_pipe_output([f'git log --pretty=format:%at "{rev}" -n 1']))
         return datetime.datetime.fromtimestamp(stamp).strftime("%Y-%m-%d")
 

--- a/gitstats/main.py
+++ b/gitstats/main.py
@@ -168,7 +168,7 @@ class DataCollector:
 
 
 class GitDataCollector(DataCollector):
-    def collect(self, repo_dir: str) -> None:
+    def collect(self, repo_dir):
         DataCollector.collect(self, repo_dir)
 
         self.total_authors += int(
@@ -235,9 +235,9 @@ class GitDataCollector(DataCollector):
                 if len(parts) < 3:
                     continue
                 commits = int(parts[1])
-                tag_author = parts[2]
+                author = parts[2]
                 self.tags[tag]["commits"] += commits
-                self.tags[tag]["authors"][tag_author] = commits
+                self.tags[tag]["authors"][author] = commits
 
         # Collect revision statistics
         # Outputs "<stamp> <date> <time> <timezone> <author> '<' <mail> '>'"
@@ -410,12 +410,12 @@ class GitDataCollector(DataCollector):
 
         # Merge aliases in time-based author dicts
         for period_dict in (self.author_of_month, self.author_of_year):
-            for author_counts in period_dict.values():
+            for period in period_dict:
                 for alias, canonical in name_to_canonical.items():
-                    if alias in author_counts:
-                        author_counts[canonical] = author_counts.get(
+                    if alias in period_dict[period]:
+                        period_dict[period][canonical] = period_dict[period].get(
                             canonical, 0
-                        ) + author_counts.pop(alias)
+                        ) + period_dict[period].pop(alias)
 
         # Merge aliases in tag author dicts
         for tag in self.tags:
@@ -471,9 +471,9 @@ class GitDataCollector(DataCollector):
             parts = line.split(" ")
             if len(parts) != 2:
                 continue
-            (stamp_text, files_text) = parts[0:2]
+            (stamp, files) = parts[0:2]
             try:
-                self.files_by_stamp[int(stamp_text)] = int(files_text)
+                self.files_by_stamp[int(stamp)] = int(files)
             except ValueError:
                 print(f'Warning: failed to parse line "{line}"')
 
@@ -553,6 +553,7 @@ class GitDataCollector(DataCollector):
         inserted = 0
         deleted = 0
         total_lines = 0
+        author = None
         for line in lines:
             if len(line) == 0:
                 continue
@@ -562,7 +563,7 @@ class GitDataCollector(DataCollector):
                 pos = line.find(" ")
                 if pos != -1:
                     try:
-                        stamp = int(line[:pos])
+                        (stamp, author) = (int(line[:pos]), line[pos + 1 :])
                         self.changes_by_date[stamp] = {
                             "files": files,
                             "ins": inserted,
@@ -627,7 +628,7 @@ class GitDataCollector(DataCollector):
         files = 0
         inserted = 0
         deleted = 0
-        author = ""
+        author = None
         stamp = 0
         for line in lines:
             if len(line) == 0:

--- a/gitstats/report_creator.py
+++ b/gitstats/report_creator.py
@@ -128,7 +128,7 @@ class HTMLReportCreator(ReportCreator):
         f.write("</body>\n</html>")
         f.close()
 
-    def create_activity_html(self, data: Any, path: str) -> None:
+    def create_activity_html(self, data, path):
         ###
         # Activity
         f = open(path + "/activity.html", "w", encoding="utf-8")
@@ -154,7 +154,7 @@ class HTMLReportCreator(ReportCreator):
         # generate years to show (previous N years from now)
         now = datetime.datetime.now()
         deltayear = datetime.timedelta(365)
-        years: list[str] = []
+        years = []
         stampcur = now
         for i in range(0, YEARS):
             years.insert(0, stampcur.strftime("%Y"))
@@ -180,7 +180,7 @@ class HTMLReportCreator(ReportCreator):
         # generate weeks to show (previous N weeks from now)
         now = datetime.datetime.now()
         deltaweek = datetime.timedelta(7)
-        weeks: list[str] = []
+        weeks = []
         stampcur = now
         for i in range(0, WEEKS):
             weeks.insert(0, stampcur.strftime("%Y-%W"))
@@ -1131,4 +1131,4 @@ def get_keys_sorted_by_values(d: dict[str, int]) -> list[str]:
 
 # dict['author'] = { 'commits': 512 } - ...key(dict, 'commits')
 def get_keys_sorted_by_value_key(d: dict[str, dict[str, Any]], key: str) -> list[str]:
-    return [el[1] for el in sorted([(d[el][key], el) for el in list(d.keys())])]
+    return [el[1] for el in sorted([(d[el][key], el) for el in d.keys()])]

--- a/gitstats/report_creator.py
+++ b/gitstats/report_creator.py
@@ -50,7 +50,7 @@ class HTMLReportCreator(ReportCreator):
     def _heat_td_class(cls, value, max_value):
         return f"heat heat{cls._heat_level(value, max_value)}"
 
-    def create(self, data, path):
+    def create(self, data: Any, path: str) -> None:
         ReportCreator.create(self, data, path)
         self.title = data.project_name
 
@@ -79,7 +79,7 @@ class HTMLReportCreator(ReportCreator):
         if hasattr(data, "ai_summaries") and data.ai_summaries:
             self.create_ai_insights_html(data, path)
 
-    def create_index_html(self, data, path):
+    def create_index_html(self, data: Any, path: str) -> None:
         f = open(path + "/index.html", "w", encoding="utf-8")
         format = "%Y-%m-%d %H:%M:%S"
         self.print_header(f)
@@ -129,7 +129,7 @@ class HTMLReportCreator(ReportCreator):
         f.write("</body>\n</html>")
         f.close()
 
-    def create_activity_html(self, data, path):
+    def create_activity_html(self, data: Any, path: str) -> None:
         ###
         # Activity
         f = open(path + "/activity.html", "w", encoding="utf-8")
@@ -437,7 +437,7 @@ class HTMLReportCreator(ReportCreator):
         cba_datasets = [{"label": a, "data": per_author_commits[a]} for a in authors_to_plot]
         return time_labels, loc_datasets, cba_datasets
 
-    def create_authors_html(self, data, path):
+    def create_authors_html(self, data: Any, path: str) -> None:
         ###
         # Authors
         f = open(path + "/authors.html", "w", encoding="utf-8")
@@ -628,7 +628,7 @@ class HTMLReportCreator(ReportCreator):
         f.write("</body></html>")
         f.close()
 
-    def create_files_html(self, data, path):
+    def create_files_html(self, data: Any, path: str) -> None:
         ###
         # Files
         f = open(path + "/files.html", "w", encoding="utf-8")
@@ -741,7 +741,7 @@ class HTMLReportCreator(ReportCreator):
         f.write("</body></html>")
         f.close()
 
-    def create_lines_html(self, data, path):
+    def create_lines_html(self, data: Any, path: str) -> None:
         ###
         # Lines
         f = open(path + "/lines.html", "w", encoding="utf-8")
@@ -771,7 +771,7 @@ class HTMLReportCreator(ReportCreator):
         f.write("</body></html>")
         f.close()
 
-    def create_tags_html(self, data, path):
+    def create_tags_html(self, data: Any, path: str) -> None:
         ###
         # tags.html
         f = open(path + "/tags.html", "w", encoding="utf-8")
@@ -814,7 +814,7 @@ class HTMLReportCreator(ReportCreator):
         f.write("</body></html>")
         f.close()
 
-    def create_ai_insights_html(self, data, path):
+    def create_ai_insights_html(self, data: Any, path: str) -> None:
         """
         Create a dedicated AI Insights page with all AI-generated summaries.
         """
@@ -970,7 +970,7 @@ class HTMLReportCreator(ReportCreator):
 </script>
 """
 
-    def print_header(self, file) -> None:
+    def print_header(self, file: Any) -> None:
         """
         Write the HTML document header and opening body tag into the provided writable file.
 
@@ -1020,7 +1020,7 @@ class HTMLReportCreator(ReportCreator):
 """.format(self.title, conf["style"], get_version)
         )
 
-    def print_nav(self, file) -> None:
+    def print_nav(self, file: Any) -> None:
         """
         Write the navigation bar HTML (page links and a client-side theme-toggle button) to the given writable file-like object.
 
@@ -1066,7 +1066,7 @@ class HTMLReportCreator(ReportCreator):
             """
         )
 
-    def get_ai_summary_html(self, page_type):
+    def get_ai_summary_html(self, page_type: str) -> str:
         """
         Generate HTML for AI-powered summary section.
 
@@ -1105,7 +1105,7 @@ class HTMLReportCreator(ReportCreator):
         """
 
 
-def html_header(level, text):
+def html_header(level: int, text: str) -> str:
     name = html_linkify(text)
     return '\n<h%d id="%s"><a href="#%s">%s</a></h%d>\n\n' % (
         level,
@@ -1116,14 +1116,14 @@ def html_header(level, text):
     )
 
 
-def html_linkify(text):
+def html_linkify(text: str) -> str:
     return text.lower().replace(" ", "_")
 
 
-def get_keys_sorted_by_values(dict):
-    return [el[1] for el in sorted([(el[1], el[0]) for el in list(dict.items())])]
+def get_keys_sorted_by_values(d: dict[str, int]) -> list[str]:
+    return [el[1] for el in sorted([(el[1], el[0]) for el in list(d.items())])]
 
 
 # dict['author'] = { 'commits': 512 } - ...key(dict, 'commits')
-def get_keys_sorted_by_value_key(d, key):
+def get_keys_sorted_by_value_key(d: dict[str, dict[str, Any]], key: str) -> list[str]:
     return [el[1] for el in sorted([(d[el][key], el) for el in list(d.keys())])]

--- a/gitstats/utils.py
+++ b/gitstats/utils.py
@@ -14,14 +14,14 @@ from gitstats import ON_LINUX, exectime_external, load_config
 conf = load_config()
 
 
-def count_lines_in_text(text):
+def count_lines_in_text(text: str | None) -> int:
     """Cross-platform function to count lines in text"""
     if not text or not text.strip():
         return 0
     return len(text.strip().split("\n"))
 
 
-def filter_lines_by_pattern(text, pattern):
+def filter_lines_by_pattern(text: str | None, pattern: str) -> str:
     """Filter out lines matching a pattern (cross-platform grep -v replacement)"""
     if not text or not text.strip():
         return ""
@@ -30,15 +30,15 @@ def filter_lines_by_pattern(text, pattern):
     return "\n".join(filtered_lines)
 
 
-def get_version():
+def get_version() -> str:
     return version("gitstats")
 
 
-def get_git_version():
+def get_git_version() -> str:
     return get_pipe_output(["git --version"]).split("\n")[0]
 
 
-def get_pipe_output(cmds, quiet=False):
+def get_pipe_output(cmds: list[str], quiet: bool = False) -> str:
     global exectime_external
     start = time.time()
     if not quiet and ON_LINUX and os.isatty(1):
@@ -93,7 +93,7 @@ def get_pipe_output(cmds, quiet=False):
     return result
 
 
-def get_commit_range(defaultrange="HEAD", end_only=False):
+def get_commit_range(defaultrange: str = "HEAD", end_only: bool = False) -> str:
     if len(conf["commit_end"]) > 0:
         commit_begin = conf["commit_begin"]
 
@@ -112,7 +112,7 @@ def get_commit_range(defaultrange="HEAD", end_only=False):
     return defaultrange
 
 
-def get_excluded_extensions():
+def get_excluded_extensions() -> set[str]:
     """
     Get the set of excluded file extensions from config.
     Returns a set of lowercase extensions.
@@ -123,7 +123,7 @@ def get_excluded_extensions():
     return {ext.strip().lower() for ext in exclude_ext_str.split(",") if ext.strip()}
 
 
-def should_exclude_file(ext):
+def should_exclude_file(ext: str) -> bool:
     """
     Check if a file should be excluded from line counting based on extension.
     Returns True if the file extension is in the exclude_exts configuration.
@@ -140,7 +140,7 @@ def should_exclude_file(ext):
     return ext.lower() in excluded_extensions
 
 
-def get_num_of_lines_in_blob(ext_blob):
+def get_num_of_lines_in_blob(ext_blob: tuple[str, str]) -> tuple[str, str, int]:
     """
     Get number of lines in blob.
     Returns 0 for binary files (detected by null bytes).
@@ -170,7 +170,7 @@ def get_num_of_lines_in_blob(ext_blob):
     )
 
 
-def get_num_of_files_from_rev(time_rev):
+def get_num_of_files_from_rev(time_rev: tuple[str, str]) -> tuple[int, str, int]:
     """
     Get number of files changed in commit
     """
@@ -182,7 +182,7 @@ def get_num_of_files_from_rev(time_rev):
     )
 
 
-def get_stat_summary_counts(line):
+def get_stat_summary_counts(line: str) -> list[str | int]:
     numbers = re.findall(r"\d+", line)
     if len(numbers) == 1:
         # neither insertions nor deletions: may probably only happen for "0 files changed"
@@ -197,7 +197,7 @@ def get_stat_summary_counts(line):
     return numbers
 
 
-def get_log_range(defaultrange="HEAD", end_only=True):
+def get_log_range(defaultrange: str = "HEAD", end_only: bool = True) -> str:
     commit_range = get_commit_range(defaultrange, end_only)
     # Build git log options
     options = []


### PR DESCRIPTION
## Summary

Adds type hints to public API methods across all core modules.

## Changes

### `__init__.py`
- `load_config()`: parameter and return type
- Global variables: `exectime_internal`, `exectime_external`, `ON_LINUX`, `WEEKDAYS`, `_config`

### `main.py`
- `DataCollector`: `__init__`, `collect`, `load_cache`, `save_cache`, `get_stamp_created`, and all `get_*()` methods
- `GitDataCollector`: `collect`, `refine`
- Also fixes `dir` → `repo_dir` parameter naming (#215)

### `report_creator.py`
- `ReportCreator`: `create`
- `HTMLReportCreator`: `create`, `create_*_html()`, `get_ai_summary_html()`, `_render_chartjs()`
- Module helpers: `html_header`, `html_linkify`, `get_keys_sorted_by_values`, `get_keys_sorted_by_value_key`
- Also fixes `dict` → `d` parameter naming in `get_keys_sorted_by_values`

### `utils.py`
- All utility functions: `count_lines_in_text`, `filter_lines_by_pattern`, `get_version`, `get_git_version`, `get_pipe_output`, `get_commit_range`, `get_excluded_extensions`, `should_exclude_file`, `get_num_of_lines_in_blob`, `get_num_of_files_from_rev`, `get_stat_summary_counts`, `get_log_range`

143 tests pass.

Closes #211, #215

<!-- readthedocs-preview gitstats start -->
----
📚 Documentation preview 📚: https://gitstats--223.org.readthedocs.build/

<!-- readthedocs-preview gitstats end -->