### PR TITLE
Remove module-level global conf from utils.py and report_creator.py

### DIFF
--- a/gitstats/report_creator.py
+++ b/gitstats/report_creator.py
@@ -17,8 +17,6 @@ from gitstats.utils import (
     get_version,
 )
 
-conf = load_config()
-
 
 class ReportCreator:
     """Creates the actual report based on given data."""
@@ -57,7 +55,7 @@ class HTMLReportCreator(ReportCreator):
         # copy static files to the report directory
         basedir = os.path.dirname(os.path.abspath(__file__))
         for file in (
-            conf["style"],
+            load_config()["style"],
             "sortable.js",
             "chart.umd.min.js",
             "arrow-up.gif",
@@ -413,7 +411,7 @@ class HTMLReportCreator(ReportCreator):
 
     def _build_author_time_series(self, data):
         """Build per-author cumulative lines and commits time series for Chart.js."""
-        authors_to_plot = data.get_authors(conf["max_authors"])
+        authors_to_plot = data.get_authors(load_config()["max_authors"])
         lines_by_authors = {a: 0 for a in authors_to_plot}
         commits_by_authors = {a: 0 for a in authors_to_plot}
         time_labels = []
@@ -453,7 +451,7 @@ class HTMLReportCreator(ReportCreator):
         f.write(
             '<tr><th>Author</th><th>Commits (%)</th><th>+ lines</th><th>- lines</th><th>First commit</th><th>Last commit</th><th class="unsortable">Age</th><th>Active days</th><th># by commits</th></tr>'
         )
-        for author in data.get_authors(conf["max_authors"]):
+        for author in data.get_authors(load_config()["max_authors"]):
             info = data.get_author_info(author)
             f.write(
                 "<tr><td>%s</td><td>%d (%.2f%%)</td><td>%d</td><td>%d</td><td>%s</td><td>%s</td><td>%s</td><td>%d</td><td>%d</td></tr>"
@@ -473,8 +471,8 @@ class HTMLReportCreator(ReportCreator):
         f.write("</table>")
 
         allauthors = data.get_authors()
-        if len(allauthors) > conf["max_authors"]:
-            rest = allauthors[conf["max_authors"] :]
+        if len(allauthors) > load_config()["max_authors"]:
+            rest = allauthors[load_config()["max_authors"] :]
             f.write(
                 '<p class="moreauthors">These didn\'t make it to the top: {}</p>'.format(
                     ", ".join(rest)
@@ -495,8 +493,8 @@ class HTMLReportCreator(ReportCreator):
                 x_ticks_rotate=True,
             )
         )
-        if len(allauthors) > conf["max_authors"]:
-            f.write('<p class="moreauthors">Only top %d authors shown</p>' % conf["max_authors"])
+        if len(allauthors) > load_config()["max_authors"]:
+            f.write('<p class="moreauthors">Only top %d authors shown</p>' % load_config()["max_authors"])
 
         f.write(html_header(2, "Commits per Author"))
         f.write(
@@ -509,22 +507,22 @@ class HTMLReportCreator(ReportCreator):
                 x_ticks_rotate=True,
             )
         )
-        if len(allauthors) > conf["max_authors"]:
-            f.write('<p class="moreauthors">Only top %d authors shown</p>' % conf["max_authors"])
+        if len(allauthors) > load_config()["max_authors"]:
+            f.write('<p class="moreauthors">Only top %d authors shown</p>' % load_config()["max_authors"])
 
         # Authors :: Author of Month
         f.write(html_header(2, "Author of Month"))
         f.write('<table class="sortable" id="aom">')
         f.write(
             '<tr><th>Month</th><th>Author</th><th>Commits (%%)</th><th class="unsortable">Next top %d</th><th>Number of authors</th></tr>'
-            % conf["authors_top"]
+            % load_config()["authors_top"]
         )
         for yymm in reversed(sorted(data.author_of_month.keys())):
             author_dict = data.author_of_month[yymm]
             authors = get_keys_sorted_by_values(author_dict)
             authors.reverse()
             commits = data.author_of_month[yymm][authors[0]]
-            authors_str = ", ".join(authors[1 : conf["authors_top"] + 1])
+            authors_str = ", ".join(authors[1 : load_config()["authors_top"] + 1])
             f.write(
                 "<tr><td>%s</td><td>%s</td><td>%d (%.2f%% of %d)</td><td>%s</td><td>%d</td></tr>"
                 % (
@@ -543,14 +541,14 @@ class HTMLReportCreator(ReportCreator):
         f.write(html_header(2, "Author of Year"))
         f.write(
             '<table class="sortable" id="aoy"><tr><th>Year</th><th>Author</th><th>Commits (%%)</th><th class="unsortable">Next top %d</th><th>Number of authors</th></tr>'
-            % conf["authors_top"]
+            % load_config()["authors_top"]
         )
         for yy in reversed(sorted(data.author_of_year.keys())):
             author_dict = data.author_of_year[yy]
             authors = get_keys_sorted_by_values(author_dict)
             authors.reverse()
             commits = data.author_of_year[yy][authors[0]]
-            authors_str = ", ".join(authors[1 : conf["authors_top"] + 1])
+            authors_str = ", ".join(authors[1 : load_config()["authors_top"] + 1])
             f.write(
                 "<tr><td>%s</td><td>%s</td><td>%d (%.2f%% of %d)</td><td>%s</td><td>%d</td></tr>"
                 % (
@@ -576,7 +574,7 @@ class HTMLReportCreator(ReportCreator):
         dom_values = []
         n = 0
         for domain in domains_by_commits:
-            if n == conf["max_domains"]:
+            if n == load_config()["max_domains"]:
                 break
             n += 1
             info = data.get_domain_info(domain)
@@ -819,7 +817,7 @@ class HTMLReportCreator(ReportCreator):
         Create a dedicated AI Insights page with all AI-generated summaries.
         """
         # Get language from config
-        language = conf.get("ai_language", "en")
+        language = load_config().get("ai_language", "en")
 
         f = open(path + "/ai-insights.html", "w", encoding="utf-8")
         self.print_header(f)
@@ -1017,7 +1015,7 @@ class HTMLReportCreator(ReportCreator):
 	</script>
 </head>
 <body>
-""".format(self.title, conf["style"], get_version)
+""".format(self.title, load_config()["style"], get_version)
         )
 
     def print_nav(self, file) -> None:

--- a/gitstats/report_creator.py
+++ b/gitstats/report_creator.py
@@ -494,7 +494,10 @@ class HTMLReportCreator(ReportCreator):
             )
         )
         if len(allauthors) > load_config()["max_authors"]:
-            f.write('<p class="moreauthors">Only top %d authors shown</p>' % load_config()["max_authors"])
+            f.write(
+                '<p class="moreauthors">Only top %d authors shown</p>'
+                % load_config()["max_authors"]
+            )
 
         f.write(html_header(2, "Commits per Author"))
         f.write(
@@ -508,7 +511,10 @@ class HTMLReportCreator(ReportCreator):
             )
         )
         if len(allauthors) > load_config()["max_authors"]:
-            f.write('<p class="moreauthors">Only top %d authors shown</p>' % load_config()["max_authors"])
+            f.write(
+                '<p class="moreauthors">Only top %d authors shown</p>'
+                % load_config()["max_authors"]
+            )
 
         # Authors :: Author of Month
         f.write(html_header(2, "Author of Month"))

--- a/gitstats/utils.py
+++ b/gitstats/utils.py
@@ -208,7 +208,9 @@ def get_log_range(defaultrange="HEAD", end_only=True):
 
     # Author filtering
     if len(load_config()["authors"]) > 0:
-        authors_list = [author.strip() for author in load_config()["authors"].split(",") if author.strip()]
+        authors_list = [
+            author.strip() for author in load_config()["authors"].split(",") if author.strip()
+        ]
         for author in authors_list:
             # Escape possible double quotes or special characters in author
             safe_author = author.replace('"', r"\"")

--- a/gitstats/utils.py
+++ b/gitstats/utils.py
@@ -11,8 +11,6 @@ from importlib.metadata import version
 
 from gitstats import ON_LINUX, exectime_external, load_config
 
-conf = load_config()
-
 
 def count_lines_in_text(text):
     """Cross-platform function to count lines in text"""
@@ -94,21 +92,21 @@ def get_pipe_output(cmds, quiet=False):
 
 
 def get_commit_range(defaultrange="HEAD", end_only=False):
-    if len(conf["commit_end"]) > 0:
-        commit_begin = conf["commit_begin"]
+    if len(load_config()["commit_end"]) > 0:
+        commit_begin = load_config()["commit_begin"]
 
         # Convert commit_begin to string for consistent handling
         commit_begin_str = str(commit_begin)
 
         # If end_only or no commit_begin specified, return just the end
         if end_only or len(commit_begin_str) == 0:
-            return conf["commit_end"]
+            return load_config()["commit_end"]
 
         # Handle numeric commit_begin as "N commits ago"
         if commit_begin_str.isdigit():
-            commit_begin_str = f"{conf['commit_end']}~{commit_begin_str}"
+            commit_begin_str = f"{load_config()['commit_end']}~{commit_begin_str}"
 
-        return "{}..{}".format(commit_begin_str, conf["commit_end"])
+        return "{}..{}".format(commit_begin_str, load_config()["commit_end"])
     return defaultrange
 
 
@@ -117,7 +115,7 @@ def get_excluded_extensions():
     Get the set of excluded file extensions from config.
     Returns a set of lowercase extensions.
     """
-    exclude_ext_str = conf.get("exclude_exts", "")
+    exclude_ext_str = load_config().get("exclude_exts", "")
     if not exclude_ext_str:
         return set()
     return {ext.strip().lower() for ext in exclude_ext_str.split(",") if ext.strip()}
@@ -203,14 +201,14 @@ def get_log_range(defaultrange="HEAD", end_only=True):
     options = []
 
     # Date range filtering
-    if len(conf["start_date"]) > 0:
-        options.append('--since="{}"'.format(conf["start_date"]))
-    if len(conf["end_date"]) > 0:
-        options.append('--until="{}"'.format(conf["end_date"]))
+    if len(load_config()["start_date"]) > 0:
+        options.append('--since="{}"'.format(load_config()["start_date"]))
+    if len(load_config()["end_date"]) > 0:
+        options.append('--until="{}"'.format(load_config()["end_date"]))
 
     # Author filtering
-    if len(conf["authors"]) > 0:
-        authors_list = [author.strip() for author in conf["authors"].split(",") if author.strip()]
+    if len(load_config()["authors"]) > 0:
+        authors_list = [author.strip() for author in load_config()["authors"].split(",") if author.strip()]
         for author in authors_list:
             # Escape possible double quotes or special characters in author
             safe_author = author.replace('"', r"\"")


### PR DESCRIPTION
## Summary

Eliminates the duplicate module-level `conf = load_config()` from `utils.py` and `report_creator.py`. Config values are now accessed via `load_config()` calls, which already caches via `_config` in `__init__.py`.

## Changes

- Removed `conf = load_config()` from `utils.py`
- Removed `conf = load_config()` from `report_creator.py`
- Replaced all `conf[...]` / `conf.get()` with `load_config()[...]` / `load_config().get()`
- `main.py` retains its module-level `conf` for CLI override handling (entry point)

This removes hidden shared state that required test fixtures to manually reset `conf` across multiple modules.

143 tests pass.

Closes #213

<!-- readthedocs-preview gitstats start -->
----
📚 Documentation preview 📚: https://gitstats--224.org.readthedocs.build/

<!-- readthedocs-preview gitstats end -->