### PR TITLE
Replace pickle cache with JSON to eliminate RCE risk

### DIFF
--- a/gitstats/main.py
+++ b/gitstats/main.py
@@ -4,12 +4,11 @@
 # GPLv2 / GPLv3
 import argparse
 import datetime
+import json
 import os
-import pickle
 import re
 import sys
 import time
-import zlib
 from multiprocessing import Pool
 from typing import Any
 
@@ -143,14 +142,13 @@ class DataCollector:
         if not os.path.exists(cachefile):
             return
         print("Loading cache...")
-        f = open(cachefile, "rb")
         try:
-            self.cache = pickle.loads(zlib.decompress(f.read()))
-        except (zlib.error, pickle.UnpicklingError):  # Specific exceptions
-            # temporary hack to upgrade non-compressed caches
-            f.seek(0)
-            self.cache = pickle.load(f)
-        f.close()
+            with open(cachefile, encoding="utf-8") as f:
+                self.cache = json.load(f)
+        except (json.JSONDecodeError, ValueError):
+            # Corrupted or legacy pickle cache - start fresh
+            print("Warning: cache is corrupted, starting fresh")
+            self.cache = {}
 
     def get_stamp_created(self):
         return self.stamp_created
@@ -159,11 +157,8 @@ class DataCollector:
     def save_cache(self, cachefile):
         print("Saving cache...")
         tempfile = cachefile + ".tmp"
-        f = open(tempfile, "wb")
-        # pickle.dump(self.cache, f)
-        data = zlib.compress(pickle.dumps(self.cache))
-        f.write(data)
-        f.close()
+        with open(tempfile, "w", encoding="utf-8") as f:
+            json.dump(self.cache, f)
         try:
             os.remove(cachefile)
         except OSError:

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -1,7 +1,6 @@
 """Tests for gitstats.main – DataCollector, parameter parsing, and integration with real git repos."""
 
 import os
-import pickle
 from unittest.mock import patch
 
 import pytest
@@ -65,18 +64,12 @@ class TestDataCollector:
 
     def test_load_cache_empty(self, temp_dir):
         cachefile = os.path.join(temp_dir, "empty.cache")
-        with open(cachefile, "wb") as f:
-            f.write(b"not a pickle at all")
+        with open(cachefile, "w") as f:
+            f.write("not valid json")
 
         dc = DataCollector()
-        # Known: load_cache has a double-failure issue where the fallback
-        # pickle.load in the except block is not guarded.
-        # This test verifies this edge case doesn't silently corrupt data.
-        try:
-            dc.load_cache(cachefile)
-        except (pickle.UnpicklingError, pickle.PickleError):
-            pass  # expected: fallback also fails
-        # Cache should remain empty
+        # JSON cache gracefully handles corrupted files
+        dc.load_cache(cachefile)
         assert dc.cache == {}
 
     def test_get_stamp_created(self):


### PR DESCRIPTION
## Summary

Replaces `pickle`+`zlib` cache serialization with standard JSON, eliminating the arbitrary code execution (RCE) vulnerability inherent in pickle deserialization.

## Changes

### `gitstats/main.py`
- Replaced `pickle.loads(zlib.decompress(...))` → `json.load()`
- Replaced `zlib.compress(pickle.dumps(...))` → `json.dump()`
- Removed `import pickle`, `import zlib`
- Added `import json`
- Added graceful `JSONDecodeError` handling for corrupted caches (fixes the known double-failure bug)

### `tests/test_main.py`
- Updated `test_load_cache_empty` to test JSON corruption handling
- Removed unused `import pickle`

## Security Impact

Before: Attackers could craft a malicious `.cache` file to execute arbitrary Python code via pickle deserialization.

After: JSON is a pure data format with no code execution capability.

Closes #212

<!-- readthedocs-preview gitstats start -->
----
📚 Documentation preview 📚: https://gitstats--227.org.readthedocs.build/

<!-- readthedocs-preview gitstats end -->