### PR TITLE
chore: add uv/uvx installation instructions to README

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -59,6 +59,13 @@ Installation
 
    pip install gitstats
 
+Or, using `uv <https://docs.astral.sh/uv/>`_ (recommended):
+
+.. code-block:: bash
+
+   uv pip install gitstats      # install into current environment
+   uvx gitstats . report        # run instantly, no install required
+
 
 gitstats is compatible with Python 3.10 and newer.
 


### PR DESCRIPTION
## Summary

Add `uv` and `uvx` quick-start entry points to the README Installation section.

## Changes

- Add `uv pip install gitstats` as an alternative install method
- Add `uvx gitstats . report` for zero-install, one-shot usage
- Link to the uv documentation

## Motivation

In 2026, many developers prefer `uv`/`uvx` over plain `pip`. Providing a copy-paste `uvx` one-liner lowers the barrier for first-time users to try gitstats instantly.

<!-- readthedocs-preview gitstats start -->
----
📚 Documentation preview 📚: https://gitstats--228.org.readthedocs.build/

<!-- readthedocs-preview gitstats end -->