### PR TITLE
docs: update Python version requirement from 3.9+ to 3.10+

### DIFF
--- a/docs/source/getting-started.rst
+++ b/docs/source/getting-started.rst
@@ -6,7 +6,7 @@ Prerequisites
 
 Before using gitstats, ensure you have the following installed:
 
-- **Python 3.9+** - Download from https://www.python.org/downloads/
+- **Python 3.10+** - Download from https://www.python.org/downloads/
 - **Git** - Download from https://git-scm.com/
 
 .. note::


### PR DESCRIPTION
## Summary

Fixes #231 — The Getting Started docs page showed **Python 3.9+** as the requirement, but the project actually requires **Python 3.10+** (as declared in `pyproject.toml`).

## Changes

- Updated `docs/source/getting-started.rst` line 9: `Python 3.9+` → `Python 3.10+`
- The `pyproject.toml` already correctly specifies `requires-python = ">=3.10"`

## Verification

```bash
$ grep 'requires-python' pyproject.toml
requires-python = ">=3.10"
```

The docs now match the actual project requirements.

<!-- readthedocs-preview gitstats start -->
----
📚 Documentation preview 📚: https://gitstats--233.org.readthedocs.build/

<!-- readthedocs-preview gitstats end -->