### PR TITLE
feat: make outputpath optional with default gitstats-report

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -128,9 +128,10 @@ Always run `pre-commit run --all-files` before committing.
 ### Command Line Usage
 
 ```bash
-gitstats <gitpath> <outputpath>
-gitstats . report  # Analyze current repo, output to 'report/'
-gitstats . report -f json  # Also generate JSON output
+gitstats <gitpath> [<outputpath>]
+gitstats .             # Analyze current repo, output to 'gitstats-report/'
+gitstats . report      # Analyze current repo, output to 'report/'
+gitstats . -f json     # Also generate JSON output
 ```
 
 ### Git Operations

--- a/README.rst
+++ b/README.rst
@@ -44,7 +44,7 @@
 Example
 -------
 
-``gitstats . report`` generates this `gitstats report <https://shenxianpeng.github.io/gitstats/index.html>`_.
+``gitstats .`` generates this `gitstats report <https://shenxianpeng.github.io/gitstats/index.html>`_.
 
 .. image:: https://raw.githubusercontent.com/shenxianpeng/gitstats/main/docs/source/demo.gif
    :alt: gitstats terminal demo
@@ -64,7 +64,7 @@ Or, using `uv <https://docs.astral.sh/uv/>`_ (recommended):
 .. code-block:: bash
 
    uv pip install gitstats      # install into current environment
-   uvx gitstats . report        # run instantly, no install required
+   uvx gitstats .              # run instantly, no install required
 
 
 gitstats is compatible with Python 3.10 and newer.
@@ -75,14 +75,16 @@ Usage
 
 .. code-block:: bash
 
-   gitstats <gitpath> <outputpath>
+   gitstats <gitpath> [<outputpath>]
+
+If ``<outputpath>`` is omitted, reports are written to ``gitstats-report/`` by default.
 
 Use ``--verbose`` to show debug-level command logs, or ``--quiet`` to show only warnings and errors:
 
 .. code-block:: bash
 
-   gitstats --verbose . report
-   gitstats --quiet . report
+   gitstats --verbose .
+   gitstats --quiet .
 
 
 Run ``gitstats --help`` for more options, or check the `documentation <https://gitstats.readthedocs.io/en/latest/getting-started.html>`_.
@@ -130,7 +132,7 @@ GitStats supports AI-powered insights to enhance your repository analysis with n
 
    # Enable AI with OpenAI
    export OPENAI_API_KEY=your-api-key
-   gitstats --ai --ai-provider openai <gitpath> <outputpath>
+   gitstats --ai --ai-provider openai <gitpath> [<outputpath>]
 
 For detailed setup instructions, configuration options, and examples, see the `AI Integration Documentation <https://gitstats.readthedocs.io/en/stable/ai-integration.html>`_.
 

--- a/docs/source/configuration.rst
+++ b/docs/source/configuration.rst
@@ -45,7 +45,7 @@ For example:
 
 .. code-block:: bash
 
-   gitstats . report -c max_authors=10 -c authors_top=3
+   gitstats . -c max_authors=10 -c authors_top=3
 
 This command will generate a report with a maximum of 10 authors displayed and the top 3 authors shown.
 
@@ -54,10 +54,10 @@ Filtering examples:
 .. code-block:: bash
 
    # Filter commits by date range
-   gitstats . report -c start_date=2024-01-01 -c end_date=2024-12-31
+   gitstats . -c start_date=2024-01-01 -c end_date=2024-12-31
 
    # Filter commits by specific authors
-   gitstats . report -c authors="John Doe,Jane Smith"
+   gitstats . -c authors="John Doe,Jane Smith"
 
    # Combine multiple filters
-   gitstats . report -c start_date=2024-01-01 -c authors="John Doe"
+   gitstats . -c start_date=2024-01-01 -c authors="John Doe"

--- a/docs/source/demo.tape
+++ b/docs/source/demo.tape
@@ -18,13 +18,13 @@ Enter
 Sleep 8s
 
 # Step 2: Generate a report for the cloned repo
-Type "gitstats . /tmp/demo/report"
+Type "gitstats ."
 Sleep 300ms
 Enter
 Sleep 15s
 
 # Step 3: Show the generated output files
-Type "python3 -m http.server 8000 --bind 127.0.0.1 -d /tmp/demo/report"
+Type "python3 -m http.server 8000 --bind 127.0.0.1 -d gitstats-report"
 Sleep 300ms
 Enter
 Sleep 2s

--- a/docs/source/getting-started.rst
+++ b/docs/source/getting-started.rst
@@ -29,7 +29,7 @@ Generate a basic report by running:
 
 .. code-block:: bash
 
-    gitstats . report
+    gitstats .
 
 .. tip::
 
@@ -37,12 +37,16 @@ Generate a basic report by running:
 
     .. code-block:: bash
 
-        uvx gitstats . report
+        uvx gitstats .
 
 Where:
 
 - ``.`` is the current directory (your Git repository), you can specify any Git repository path.
-- ``report`` is the output directory where HTML files will be generated
+- By default, reports are generated into ``gitstats-report/``. You can specify a custom output directory:
+
+  .. code-block:: bash
+
+      gitstats . my-custom-report
 
 View a live example: https://shenxianpeng.github.io/gitstats/index.html
 
@@ -54,7 +58,7 @@ To generate both HTML and JSON formats:
 
 .. code-block:: bash
 
-    gitstats . report --format json
+    gitstats . --format json
 
 This creates a ``report.json`` file alongside the HTML report.
 
@@ -76,12 +80,12 @@ Basic Syntax
 
 .. code-block:: bash
 
-    gitstats [options] <gitpath> <outputpath>
+    gitstats [options] <gitpath> [<outputpath>]
 
 **Arguments:**
 
 - ``<gitpath>`` - Path to your Git repository (e.g., ``.`` for current directory)
-- ``<outputpath>`` - Directory where the report will be generated
+- ``<outputpath>`` - Directory where the report will be generated (default: ``gitstats-report``)
 
 **Options:**
 
@@ -98,13 +102,13 @@ Full Help Output
 .. code-block:: text
 
     usage: gitstats [-h] [-v] [-c key=value] [-f {json}] [--verbose | --quiet]
-                    <gitpath> [<gitpath> ...] <outputpath>
+                    <gitpath> [<gitpath> ...] [<outputpath>]
 
     Generate statistics for a Git repository.
 
     positional arguments:
       <gitpath>             Path(s) to the Git repository
-      <outputpath>          Path to the directory where the output will be stored
+      <outputpath>          Path to the output directory (default: gitstats-report)
 
     options:
       -h, --help            show this help message and exit
@@ -124,6 +128,12 @@ Generate report for current directory:
 
 .. code-block:: bash
 
+    gitstats .
+
+Generate report to a custom output directory:
+
+.. code-block:: bash
+
     gitstats . my-report
 
 Generate report for specific repository:
@@ -136,24 +146,24 @@ Generate report with JSON output:
 
 .. code-block:: bash
 
-    gitstats . report --format json
+    gitstats . --format json
 
 Show command-level debug logs:
 
 .. code-block:: bash
 
-    gitstats --verbose . report
+    gitstats --verbose .
 
 Show only warnings and errors:
 
 .. code-block:: bash
 
-    gitstats --quiet . report
+    gitstats --quiet .
 
 Override configuration values:
 
 .. code-block:: bash
 
-    gitstats . report -c max_authors=10 -c authors_top=3
+    gitstats . -c max_authors=10 -c authors_top=3
 
 For more configuration options, see the :doc:`configuration` page.

--- a/gitstats/main.py
+++ b/gitstats/main.py
@@ -949,12 +949,14 @@ def get_parser() -> argparse.ArgumentParser:
         "gitpath",
         metavar="<gitpath>",
         nargs="+",
-        help="Path to the Git repository",
+        help="Path to the Git repository. An optional output directory may follow.",
     )
     parser.add_argument(
         "outputpath",
         metavar="<outputpath>",
-        help="Path to the directory where the output will be stored",
+        nargs="?",
+        default=None,
+        help="Path to the output directory (default: gitstats-report)",
     )
 
     parser.add_argument(
@@ -1014,6 +1016,16 @@ def main() -> int:
     parser = get_parser()
     args = parser.parse_args()
     configure_logging(verbose=args.verbose, quiet=args.quiet)
+
+    # Resolve positional arguments: gitpath (nargs='+') consumes all positional args.
+    # If outputpath is None and more than one arg was given, move the last arg from
+    # gitpath to outputpath.
+    if args.outputpath is None:
+        if len(args.gitpath) > 1:
+            *repo_paths, args.outputpath = args.gitpath
+            args.gitpath = repo_paths
+        else:
+            args.outputpath = "gitstats-report"
 
     gitpath = args.gitpath
     outputpath = os.path.abspath(args.outputpath)

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -455,13 +455,21 @@ class TestCLI:
     def test_parser_defaults(self):
         parser = get_parser()
         args = parser.parse_args(["some-repo", "out-dir"])
-        assert args.gitpath == ["some-repo"]
-        assert args.outputpath == "out-dir"
+        # With nargs='+' + nargs='?', argparse greedily consumes all
+        # positional args into gitpath. Resolution happens in main().
+        assert args.gitpath == ["some-repo", "out-dir"]
+        assert args.outputpath is None
         assert args.format is None
         assert args.verbose is False
         assert args.quiet is False
         assert args.ai is None
         assert args.refresh_ai is False
+
+    def test_parser_single_path(self):
+        parser = get_parser()
+        args = parser.parse_args(["some-repo"])
+        assert args.gitpath == ["some-repo"]
+        assert args.outputpath is None
 
     def test_parser_format(self):
         parser = get_parser()
@@ -553,6 +561,24 @@ def test_main_basic(git_repo_minimal, temp_dir):
     with patch.object(sys, "argv", ["gitstats", git_repo_minimal, output]):
         ret = main()
     assert ret == 0
+
+
+def test_main_default_outputpath(git_repo_minimal, temp_dir):
+    """Test main() without explicit outputpath (uses default gitstats-report)."""
+    import gitstats
+    import gitstats.main
+
+    cfg = dict(gitstats.DEFAULT_CONFIG, ai_enabled=False)
+    gitstats._config = cfg
+    gitstats.main.conf = cfg
+
+    import sys
+
+    with patch.object(sys, "argv", ["gitstats", git_repo_minimal]):
+        ret = main()
+    assert ret == 0
+    # Default output dir should have been created
+    assert os.path.isdir("gitstats-report")
 
 
 def test_main_with_config_override(git_repo_minimal, temp_dir):


### PR DESCRIPTION
## Summary

Make the `<outputpath>` positional argument optional. When omitted, reports are written to `gitstats-report/` by default.

## Motivation

The common case is `gitstats .` — users shouldn't have to type a directory name every time. This reduces CLI friction while preserving full backward compatibility.

## Changes

- **main.py**: `outputpath` changed from required to `nargs='?'` with manual fallback logic (argparse `nargs='+'` greediness workaround)
- **README.rst**: updated usage examples
- **docs/source/getting-started.rst**: updated Quick Start, syntax, and examples
- **docs/source/configuration.rst**: updated config override examples
- **docs/source/demo.tape**: updated terminal demo recording script
- **.github/copilot-instructions.md**: updated usage hints

## Backward Compatibility

| Usage | Before | After |
|-------|--------|-------|
| `gitstats . report` | ✅ | ✅ (report = outputpath) |
| `gitstats .` | ❌ error | ✅ → gitstats-report/ |
| `gitstats r1 r2 out` | ✅ | ✅ |
| CI scripts | ✅ | ✅ (unchanged) |

## Testing

- `nox -s lint` — ✅ all checks pass
- `nox -s build` — ✅ generates report successfully
- Manual test: `gitstats .` → outputs to `gitstats-report/`

<!-- readthedocs-preview gitstats start -->
----
📚 Documentation preview 📚: https://gitstats--236.org.readthedocs.build/

<!-- readthedocs-preview gitstats end -->