### PR TITLE
feat: add longest consecutive active days streak

### DIFF
--- a/gitstats/main.py
+++ b/gitstats/main.py
@@ -112,6 +112,7 @@ class DataCollector:
         self.last_commit_stamp: int = 0
         self.last_active_day: str | None = None
         self.active_days: set[str] = set()
+        self.longest_streak: int = 0  # longest consecutive active days streak
 
         # lines
         self.total_lines: int = 0
@@ -741,8 +742,23 @@ class GitDataCollector(DataCollector):
                     self.new_contributors_by_month.get(first_month, 0) + 1
                 )
 
+        # Compute longest consecutive active days streak
+        dates = sorted(datetime.datetime.strptime(d, "%Y-%m-%d") for d in self.active_days)
+        longest, current = 0, 0
+        for i, d in enumerate(dates):
+            if i == 0:
+                current = 1
+            else:
+                diff = (d - dates[i - 1]).days
+                current = current + 1 if diff <= 1 else 1
+            longest = max(longest, current)
+        self.longest_streak = longest
+
     def get_active_days(self) -> set[str]:
         return self.active_days
+
+    def get_longest_streak(self) -> int:
+        return self.longest_streak
 
     def get_activity_by_day_of_week(self) -> dict[int, int]:
         return self.activity_by_day_of_week

--- a/gitstats/report_creator.py
+++ b/gitstats/report_creator.py
@@ -112,6 +112,9 @@ class HTMLReportCreator(ReportCreator):
                 (100.0 * len(data.get_active_days()) / data.get_commit_delta_days()),
             )
         )
+        f.write(
+            f"<tr><td>Longest Streak</td><td>{data.get_longest_streak()} consecutive active days</td></tr>"
+        )
         f.write(f"<tr><td>Total Files</td><td>{data.get_total_files()}</td></tr>")
         f.write(
             "<tr><td>Total Lines of Code</td><td>%s (%d added, %d removed)</td></tr>"
@@ -135,6 +138,14 @@ class HTMLReportCreator(ReportCreator):
         self.print_header(f)
         self.print_nav(f)
         f.write("<h1>Activity</h1>")
+
+        # Streak summary
+        longest_streak = data.get_longest_streak()
+        if longest_streak > 0:
+            f.write(
+                "<p><strong>Longest Streak:</strong> %d consecutive active days. "
+                "A long streak indicates sustained development momentum.</p>" % longest_streak
+            )
 
         # f.write('<h2>Last 30 days</h2>')
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -227,6 +227,8 @@ def mock_data_collector():
     data.get_active_days.return_value = set(
         ["2023-01-01", "2023-01-15", "2023-02-01", "2023-03-10"]
     )
+    data.get_longest_streak.return_value = 4
+    data.longest_streak = 4
     data.get_commit_delta_days.return_value = 120
 
     # Activity


### PR DESCRIPTION
## Summary

Adds **Longest Streak** — the longest consecutive number of days with at least one commit — inspired by GitScope's feature.

## Changes

| File | Change |
|------|--------|
| `gitstats/main.py` | New `longest_streak` field in `DataCollector`, streak computation in `refine()`, `get_longest_streak()` accessor |
| `gitstats/report_creator.py` | Display streak on General page (after Project Age) and Activity page |
| `tests/conftest.py` | Add `get_longest_streak` to mock fixture |

## How it works

Uses the existing `active_days` set (`{"2024-01-15", ...}`) to compute the longest run of consecutive dates in `O(n log n)` time during `refine()`.

## Verification

- ✅ `nox -s lint` — all checks pass
- ✅ `nox -s build` — report generated with `Longest Streak: 6 consecutive active days`
- ✅ `pytest` — 148/148 tests pass

<!-- readthedocs-preview gitstats start -->
----
📚 Documentation preview 📚: https://gitstats--237.org.readthedocs.build/

<!-- readthedocs-preview gitstats end -->