### PR TITLE
ci: fix gallery workflow by installing gitstats with pipx

### DIFF
--- a/.github/workflows/gallery.yml
+++ b/.github/workflows/gallery.yml
@@ -29,16 +29,14 @@ jobs:
           python-version: "3.10"
 
       - name: Install GitStats
-        run: |
-          pip install --upgrade pip
-          pip install -e .
+        run: pipx install --python "$(which python)" .
 
       - name: Generate Report
         env:
           FONTCONFIG_FILE: /dev/null
         run: |
           git clone "https://github.com/${{ matrix.repo.url }}.git" /tmp/repo
-          python -m gitstats /tmp/repo "report"
+          gitstats /tmp/repo "report"
 
       - name: Upload Artifact
         uses: actions/upload-artifact@v7


### PR DESCRIPTION
## Summary

The gallery workflow ([run 28708611599](https://github.com/shenxianpeng/gitstats/actions/runs/28708611599)) failed at the *Generate Report* step:

```
python: No module named gitstats.__main__; 'gitstats' is a package and cannot be directly executed
```

The package has no `__main__.py`, so `python -m gitstats` cannot work. This PR switches the workflow to install with **pipx** and invoke the `gitstats` console script directly:

- **Install GitStats**: `pipx install --python "$(which python)" .` — pipx is pre-installed on GitHub-hosted runners; `--python` pins it to the Python version selected by `setup-python` (3.10)
- **Generate Report**: `gitstats /tmp/repo report` instead of `python -m gitstats`

Verified locally that the `gitstats` console script (from `[project.scripts]`) installs and runs (`gitstats --version`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GMAQ9RuvP1XPZL1B52m3tN

---
_Generated by [Claude Code](https://claude.ai/code/session_01GMAQ9RuvP1XPZL1B52m3tN)_

<!-- readthedocs-preview gitstats start -->
----
📚 Documentation preview 📚: https://gitstats--244.org.readthedocs.build/

<!-- readthedocs-preview gitstats end -->