### PR TITLE
ci: fetch tags in gallery workflow so setuptools-scm derives the real version

### DIFF
--- a/.github/workflows/gallery.yml
+++ b/.github/workflows/gallery.yml
@@ -23,6 +23,10 @@ jobs:
 
     steps:
       - uses: actions/checkout@v7
+        with:
+          # setuptools-scm needs tags to derive the version shown in reports
+          fetch-depth: 0
+          fetch-tags: true
 
       - uses: actions/setup-python@v6
         with:


### PR DESCRIPTION
## Summary

The gallery workflow installed gitstats as `0.0.0.post1.dev1` because the default `actions/checkout` shallow clone contains no tags. gitstats derives its version dynamically via **setuptools-scm** (`dynamic = ["version"]`), and with no tag visible it falls back to `fallback_version = "0.0.0"`, which then shows up in the footer of every generated gallery report.

Fix: fetch full history and tags in the checkout step of the `generate` job:

```yaml
- uses: actions/checkout@v7
  with:
    fetch-depth: 0
    fetch-tags: true
```

With tags available, setuptools-scm resolves the real version (e.g. `2.x.y.post1.devN`) and the reports display it correctly. Cosmetic only — report generation itself was unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GMAQ9RuvP1XPZL1B52m3tN

---
_Generated by [Claude Code](https://claude.ai/code/session_01GMAQ9RuvP1XPZL1B52m3tN)_

<!-- readthedocs-preview gitstats start -->
----
📚 Documentation preview 📚: https://gitstats--245.org.readthedocs.build/

<!-- readthedocs-preview gitstats end -->