### PR TITLE
feat: add hotspots analysis page (change frequency × file size scatter plot)

### DIFF
--- a/gitstats/gitstats.css
+++ b/gitstats/gitstats.css
@@ -550,6 +550,44 @@ table.noborders td:hover .bar {
 	line-height: 1.6;
 }
 
+/* ===== Hotspots Analysis ===== */
+.hotspots-intro {
+	padding: var(--space-3) var(--space-4);
+	margin: var(--space-3) 0;
+	background-color: var(--surface-color);
+	border: 1px solid var(--border-strong);
+	border-left: 3px solid var(--danger-color);
+}
+
+.hotspots-intro p {
+	margin: 0;
+	line-height: 1.6;
+	font-size: var(--font-size-sm);
+	color: var(--text-secondary);
+}
+
+.hotspots-summary {
+	margin: var(--space-3) 0;
+	font-size: var(--font-size-sm);
+	color: var(--text-secondary);
+	font-family: var(--font-mono);
+	display: flex;
+	flex-wrap: wrap;
+	gap: var(--space-1);
+}
+
+.hotspot-stat-sep {
+	color: var(--text-muted);
+	margin: 0 var(--space-1);
+}
+
+.risk-critical {
+	color: #cf222e;
+	font-weight: 700;
+}
+
+[data-theme="dark"] .risk-critical { color: #f87171; }
+
 /* ===== Footer ===== */
 .footer {
 	margin-top: var(--space-6);

--- a/gitstats/main.py
+++ b/gitstats/main.py
@@ -143,6 +143,9 @@ class DataCollector:
         # code ownership: author -> file path -> number of commits touching it
         self.author_files: dict[str, dict[str, int]] = {}
 
+        # hotspot files: change frequency × file size analysis
+        self.hotspot_files: dict[str, dict[str, int]] = {}  # filepath -> { churn, lines, score }
+
         # new contributors per month
         self.new_contributors_by_month: dict[str, int] = {}  # YYYY-MM -> count
 
@@ -552,6 +555,22 @@ class GitDataCollector(DataCollector):
             self.cache["lines_in_blob"][blob_id] = linecount
             self.extensions[ext]["lines"] += self.cache["lines_in_blob"][blob_id]
 
+        # Collect per-file line counts for hotspot analysis
+        # Re-parse the same ls-tree output; line counts are now resolved in cache
+        self.hotspot_files = {}
+        for ls_line in lines:
+            if not ls_line:
+                continue
+            ls_parts = re.split(r"\s+", ls_line, 4)
+            if ls_parts[0] == "160000" and ls_parts[3] == "-":
+                continue
+            hs_blob_id = ls_parts[2]
+            fullpath = ls_parts[4]
+            hs_lines = 0
+            if "lines_in_blob" in self.cache and hs_blob_id in self.cache["lines_in_blob"]:
+                hs_lines = self.cache["lines_in_blob"][hs_blob_id]
+            self.hotspot_files[fullpath] = {"lines": hs_lines, "churn": 0, "score": 0.0}
+
         # line statistics
         # outputs:
         #  N files changed, N insertions (+), N deletions(-)
@@ -774,6 +793,15 @@ class GitDataCollector(DataCollector):
                 current = current + 1 if diff <= 1 else 1
             longest = max(longest, current)
         self.longest_streak = longest
+
+        # Merge file_churn into hotspot_files and compute hotspot score
+        for filepath in self.hotspot_files:
+            churn = self.file_churn.get(filepath, 0)
+            self.hotspot_files[filepath]["churn"] = churn
+            lines = self.hotspot_files[filepath]["lines"]
+            # Hotspot score: churn * sqrt(lines) — amplifies files that are both
+            # frequently changed AND large in size
+            self.hotspot_files[filepath]["score"] = churn * (lines**0.5)
 
     def get_active_days(self) -> set[str]:
         return self.active_days

--- a/gitstats/report_creator.py
+++ b/gitstats/report_creator.py
@@ -78,6 +78,7 @@ class HTMLReportCreator(ReportCreator):
         self.create_lines_html(data, path)
         self.create_tags_html(data, path)
         self.create_ownership_html(data, path)
+        self.create_hotspots_html(data, path)
 
         # Create AI Insights page if AI is enabled
         if hasattr(data, "ai_summaries") and data.ai_summaries:
@@ -1054,6 +1055,245 @@ class HTMLReportCreator(ReportCreator):
         f.write("</body></html>")
         f.close()
 
+    def create_hotspots_html(self, data: Any, path: str) -> None:
+        """
+        Create a Hotspots Analysis page with scatter plot of change frequency × file size.
+
+        Hotspots are files that are both frequently changed and large in size —
+        they are the most bug-prone files in the codebase (CodeScene concept).
+        """
+        hotspot_data = getattr(data, "hotspot_files", {})
+        if not hotspot_data:
+            return
+
+        f = self._open_report_file(path, "hotspots.html")
+        self.print_header(f)
+        self.print_nav(f)
+        f.write("<h1>Hotspots Analysis</h1>")
+
+        f.write("""
+        <div class="hotspots-intro">
+            <p>Files changed often <em>and</em> large in size are the most bug-prone.
+            Each dot is a file — bigger dot = higher risk.
+            Dashed lines show the median file size and change frequency.</p>
+        </div>
+        """)
+
+        # Build scatter data: filter to files with churn > 0 and lines > 0
+        scatter_points = []
+        for filepath, info in hotspot_data.items():
+            churn = info.get("churn", 0)
+            lines = info.get("lines", 0)
+            score = info.get("score", 0.0)
+            if churn > 0 and lines > 0:
+                scatter_points.append(
+                    {
+                        "path": filepath,
+                        "x": lines,
+                        "y": churn,
+                        "score": round(score, 1),
+                    }
+                )
+
+        if not scatter_points:
+            f.write(
+                "<p>No hotspot data available. Files must have been touched by at least one commit and have > 0 lines.</p>"
+            )
+            self.print_footer(f)
+            f.write("</body></html>")
+            f.close()
+            return
+
+        # Compute medians for quadrant lines
+        lines_list = [p["x"] for p in scatter_points]
+        churn_list = [p["y"] for p in scatter_points]
+        lines_list.sort()
+        churn_list.sort()
+        n = len(scatter_points)
+        median_x = lines_list[n // 2] if n else 0
+        median_y = churn_list[n // 2] if n else 0
+
+        # Serialize to JSON for Chart.js
+        scatter_json = json.dumps(scatter_points).replace("</", "<\\/")
+
+        f.write(f"""
+        <div style="max-width:100%;margin-bottom:8px">
+            <canvas id="chart-hotspots"></canvas>
+        </div>
+        <script>
+        (function() {{
+            var points = {scatter_json};
+
+            var medianX = {median_x};
+            var medianY = {median_y};
+
+            // Build Chart.js scatter datasets with color by quadrant
+            // Point size scales with hotspot score: bigger = riskier
+            var allScores = points.map(function(p) {{ return p.score; }});
+            var maxScore = Math.max.apply(null, allScores);
+            var minScore = Math.min.apply(null, allScores);
+            var scoreRange = maxScore - minScore || 1;
+
+            var scatterData = points.map(function(p) {{
+                var color;
+                var quadrant;
+                if (p.x >= medianX && p.y >= medianY) {{
+                    color = '#cf222e';  // critical (top-right)
+                    quadrant = 'critical';
+                }} else if (p.x < medianX && p.y >= medianY) {{
+                    color = '#e16f24';  // warning (top-left)
+                    quadrant = 'warning';
+                }} else if (p.x >= medianX && p.y < medianY) {{
+                    color = '#1a7f37';  // calm (bottom-right)
+                    quadrant = 'calm';
+                }} else {{
+                    color = '#5b8dee';  // safe (bottom-left)
+                    quadrant = 'safe';
+                }}
+                // Normalize radius: 3 (min) to 12 (max) based on score percentile
+                var norm = (p.score - minScore) / scoreRange;
+                var radius = 3 + norm * 9;
+                return {{
+                    x: p.x,
+                    y: p.y,
+                    path: p.path,
+                    score: p.score,
+                    quadrant: quadrant,
+                    backgroundColor: color,
+                    borderColor: color,
+                    pointRadius: radius,
+                    pointHoverRadius: radius + 4,
+                }};
+            }});
+
+            // Custom plugin to draw quadrant median lines
+            var quadrantPlugin = {{
+                id: 'quadrantLines',
+                afterDraw: function(chart) {{
+                    var ctx = chart.ctx;
+                    var chartArea = chart.chartArea;
+                    var xScale = chart.scales.x;
+                    var yScale = chart.scales.y;
+
+                    var x = xScale.getPixelForValue(medianX);
+                    var y = yScale.getPixelForValue(medianY);
+
+                    ctx.save();
+                    ctx.strokeStyle = 'rgba(100, 100, 100, 0.6)';
+                    ctx.lineWidth = 1.5;
+                    ctx.setLineDash([6, 4]);
+
+                    // Vertical line (median file size)
+                    ctx.beginPath();
+                    ctx.moveTo(x, chartArea.top);
+                    ctx.lineTo(x, chartArea.bottom);
+                    ctx.stroke();
+
+                    // Horizontal line (median change frequency)
+                    ctx.beginPath();
+                    ctx.moveTo(chartArea.left, y);
+                    ctx.lineTo(chartArea.right, y);
+                    ctx.stroke();
+
+                    ctx.restore();
+                }}
+            }};
+
+            var ctx = document.getElementById('chart-hotspots').getContext('2d');
+            new Chart(ctx, {{
+                type: 'scatter',
+                data: {{
+                    datasets: [{{
+                        label: 'Files',
+                        data: scatterData,
+                        pointHitRadius: 10,
+                    }}]
+                }},
+                options: {{
+                    responsive: true,
+                    maintainAspectRatio: true,
+                    aspectRatio: 3.0,
+                    plugins: {{
+                        legend: {{ display: false }},
+                        tooltip: {{
+                            callbacks: {{
+                                label: function(context) {{
+                                    var p = context.raw;
+                                    return ' ' + p.path + ' | ' + p.x + ' lines, changed ' + p.y + ' times, score: ' + p.score;
+                                }}
+                            }}
+                        }}
+                    }},
+                    scales: {{
+                        x: {{
+                            type: 'logarithmic',
+                            title: {{ display: true, text: 'File Size (lines of code)' }},
+                            min: 1,
+                            ticks: {{
+                                callback: function(value) {{
+                                    if (value >= 1000) return (value/1000) + 'k';
+                                    return value;
+                                }}
+                            }}
+                        }},
+                        y: {{
+                            type: 'logarithmic',
+                            title: {{ display: true, text: 'Change Frequency (commits)' }},
+                            min: 1,
+                            ticks: {{
+                                callback: function(value) {{
+                                    return value;
+                                }}
+                            }}
+                        }}
+                    }}
+                }},
+                plugins: [quadrantPlugin]
+            }});
+        }})();
+        </script>
+        """)
+
+        # Critical files = top-right quadrant of the scatter plot
+        # (above median in both lines and changes)
+        # This ensures red dots on the chart match the files in the table
+        critical_files = [p for p in scatter_points if p["x"] >= median_x and p["y"] >= median_y]
+        critical_files.sort(key=lambda p: p["score"], reverse=True)
+
+        # Summary stat line
+        f.write(f"""
+        <div class="hotspots-summary">
+            <span class="hotspot-stat">{len(scatter_points)} files changed</span>
+            <span class="hotspot-stat-sep">|</span>
+            <span class="hotspot-stat"><strong class="risk-critical">{len(critical_files)} critical</strong> (top-right quadrant)</span>
+            <span class="hotspot-stat-sep">|</span>
+            <span class="hotspot-stat">median {median_x} lines, {median_y} changes</span>
+        </div>
+        """)
+
+        # Show critical files in the table (matches red dots on the scatter plot)
+        if critical_files:
+            f.write(html_header(2, f"Critical Hotspots ({len(critical_files)})"))
+            f.write("""
+            <table class="sortable" id="hotspots">
+            <tr>
+                <th>File</th>
+                <th>Lines</th>
+                <th>Changes</th>
+                <th>Score</th>
+            </tr>
+            """)
+            for p in critical_files:
+                f.write(
+                    "<tr><td>%s</td><td>%d</td><td>%d</td><td>%.1f</td></tr>"
+                    % (html.escape(p["path"]), p["x"], p["y"], p["score"])
+                )
+            f.write("</table>")
+
+        self.print_footer(f)
+        f.write("</body></html>")
+        f.close()
+
     def create_ai_insights_html(self, data: Any, path: str) -> None:
         """
         Create a dedicated AI Insights page with all AI-generated summaries.
@@ -1313,6 +1553,7 @@ class HTMLReportCreator(ReportCreator):
             <li><a href="lines.html">Lines</a></li>
             <li><a href="tags.html">Tags</a></li>
             <li><a href="ownership.html">Code Ownership</a></li>
+            <li><a href="hotspots.html">Hotspots</a></li>
             {ai_link}
             </ul>
             <div class="nav-right">

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -354,6 +354,14 @@ def mock_data_collector():
         "Charlie Brown": {"main.py": 1},
     }
 
+    # Hotspots: filepath -> { churn, lines, score }
+    data.hotspot_files = {
+        "main.py": {"churn": 15, "lines": 400, "score": 300.0},
+        "utils.py": {"churn": 10, "lines": 120, "score": 109.5},
+        "README.md": {"churn": 8, "lines": 60, "score": 62.0},
+        "Dockerfile": {"churn": 2, "lines": 30, "score": 11.0},
+    }
+
     # Changes by date (lines)
     data.changes_by_date = {}
 

--- a/tests/test_report_creator.py
+++ b/tests/test_report_creator.py
@@ -646,6 +646,7 @@ def test_create_all_pages(mock_data_collector, temp_dir):
         "lines.html",
         "tags.html",
         "ownership.html",
+        "hotspots.html",
     ]
     for fname in expected_files:
         path = f"{temp_dir}/{fname}"
@@ -760,3 +761,44 @@ def test_open_report_file_confined_to_report_dir(temp_dir):
     assert os.path.exists(f"{temp_dir}/ownership.html")
     with pytest.raises(ValueError):
         creator._open_report_file(temp_dir, "../escape.html")
+
+
+# ── Hotspots page ────────────────────────────────────────────────────────
+
+
+def test_hotspots_page_renders(mock_data_collector, temp_dir):
+    creator = HTMLReportCreator()
+    creator.create(mock_data_collector, temp_dir)
+
+    with open(f"{temp_dir}/hotspots.html", encoding="utf-8") as f:
+        content = f.read()
+
+    assert "Hotspots Analysis" in content
+    # scatter data inlined for Chart.js
+    assert "chart-hotspots" in content
+    assert "main.py" in content
+    assert "</html>" in content
+
+
+def test_hotspots_page_skipped_when_no_data(mock_data_collector, temp_dir):
+    mock_data_collector.hotspot_files = {}
+    creator = HTMLReportCreator()
+    creator.create(mock_data_collector, temp_dir)
+
+    # With no hotspot data the page is not generated at all
+    assert not os.path.exists(f"{temp_dir}/hotspots.html")
+
+
+def test_hotspots_page_escapes_paths(mock_data_collector, temp_dir):
+    mock_data_collector.hotspot_files = {
+        "we<i>rd.py": {"churn": 9, "lines": 500, "score": 201.0},
+        "plain.py": {"churn": 2, "lines": 10, "score": 6.0},
+    }
+    creator = HTMLReportCreator()
+    creator.create(mock_data_collector, temp_dir)
+
+    with open(f"{temp_dir}/hotspots.html", encoding="utf-8") as f:
+        content = f.read()
+
+    # The table cell must be HTML-escaped
+    assert "we&lt;i&gt;rd.py" in content


### PR DESCRIPTION
## Summary

Adds a **Hotspots Analysis** page that visualizes the relationship between **change frequency** and **file size** using a scatter plot — inspired by CodeScene's hotspot analysis for identifying the most bug-prone files.

### What's new

- **Scatter plot** (Chart.js): X-axis = file size (log scale), Y-axis = change frequency (log scale)
- **Quadrant coloring**: Critical (top-right, red) / Warning (top-left, orange) / Stable (bottom-right, green) / Safe (bottom-left, blue)
- **Median quadrant lines**: Dashed lines at median values for both axes
- **Tooltip on hover**: Shows file path, lines, change count, and hotspot score
- **Top 50 hotspot table**: Sorted by `score = churn × √lines`, with risk levels
- **Summary statistics**: Median values, critical hotspot count, etc.
- **Navigation**: Hotspots link added to all pages

### How it works

| Dimension | Implementation |
|-----------|---------------|
| Data collection | Reuses existing `lines_in_blob` cache + `file_churn` — zero additional Git overhead |
| Scoring formula | `churn × √lines` — amplifies files that are both frequently changed and large |
| File sizes | Collected during existing `git ls-tree` pass, cached per blob |
| Visualization | Chart.js scatter type with custom plugin for median lines |

### Demo

```
Files analyzed: 46
Median file size: 76 lines
Median change frequency: 3 commits
Critical hotspots (top-right quadrant): 16
```

### Files changed

- `gitstats/main.py` — `hotspot_files` data collection + merge with `file_churn`
- `gitstats/report_creator.py` — New `create_hotspots_html()` method + nav link
- `gitstats/gitstats.css` — Hotspot-specific styles (quadrant colors, risk levels)

Closes # (no issue filed)

<!-- readthedocs-preview gitstats start -->
----
📚 Documentation preview 📚: https://gitstats--246.org.readthedocs.build/

<!-- readthedocs-preview gitstats end -->