### PR TITLE
fix: add checkout step to gallery workflow

### DIFF
--- a/.github/workflows/gallery.yml
+++ b/.github/workflows/gallery.yml
@@ -54,6 +54,8 @@ jobs:
     permissions:
       contents: write
     steps:
+      - uses: actions/checkout@v7
+
       - uses: actions/download-artifact@v7
         with:
           pattern: report-*


### PR DESCRIPTION
## Summary
Added a missing `actions/checkout@v7` step to the gallery workflow before downloading artifacts.

## Key Changes
- Added `actions/checkout@v7` step at the beginning of the job's steps
- This ensures the repository is checked out before attempting to download artifacts

## Implementation Details
The checkout step is now properly positioned before the `actions/download-artifact@v7` step, which is a best practice in GitHub Actions workflows. This guarantees that the working directory is initialized with the repository contents before any subsequent steps execute.

https://claude.ai/code/session_018tGp6ckSYnGMCpjeSZgTgZ

<!-- readthedocs-preview gitstats start -->
----
📚 Documentation preview 📚: https://gitstats--251.org.readthedocs.build/

<!-- readthedocs-preview gitstats end -->