### PR TITLE
feat: add Code Ownership page

### DIFF
--- a/gitstats/gitstats.css
+++ b/gitstats/gitstats.css
@@ -533,6 +533,23 @@ table.noborders td:hover .bar {
 	color: var(--text-secondary);
 }
 
+/* ===== Code Ownership ===== */
+.ownership-summary {
+	padding: var(--space-4);
+	margin: var(--space-4) 0;
+	background-color: var(--surface-color);
+	border: 1px solid var(--border-strong);
+}
+
+.ownership-summary p:first-child {
+	margin-top: 0;
+}
+
+.ownership-summary p {
+	color: var(--text-secondary);
+	line-height: 1.6;
+}
+
 /* ===== Footer ===== */
 .footer {
 	margin-top: var(--space-6);

--- a/gitstats/main.py
+++ b/gitstats/main.py
@@ -140,6 +140,9 @@ class DataCollector:
         # file churn: number of commits that touched each file path
         self.file_churn: dict[str, int] = {}  # filepath -> commit count
 
+        # code ownership: author -> file path -> number of commits touching it
+        self.author_files: dict[str, dict[str, int]] = {}
+
         # new contributors per month
         self.new_contributors_by_month: dict[str, int] = {}  # YYYY-MM -> count
 
@@ -700,14 +703,28 @@ class GitDataCollector(DataCollector):
                     logger.warning(f'Failed to handle line "{line}"')
                     (files, inserted, deleted) = (0, 0, 0)
 
-        # File churn: count how many commits touched each file
+        # Single name-only pass drives two metrics:
+        #   * file_churn   -> how many commits touched each file
+        #   * author_files -> which files each author touches (code ownership)
+        # Each commit is prefixed with a "COMMIT:<author>" marker line; the lines
+        # that follow are the file paths changed by that commit. Authors are
+        # resolved to their canonical identity so aliases merge here directly.
         churn_output = get_pipe_output(
-            ['git log --format="" --name-only {}'.format(get_log_range("HEAD", False))]
+            ['git log --format="COMMIT:%aN" --name-only {}'.format(get_log_range("HEAD", False))]
         )
+        current_author = None
         for line in churn_output.split("\n"):
             line = line.strip()
-            if line:
-                self.file_churn[line] = self.file_churn.get(line, 0) + 1
+            if not line:
+                continue
+            if line.startswith("COMMIT:"):
+                current_author = name_to_canonical.get(line[7:], line[7:])
+                continue
+            # A changed-file line.
+            self.file_churn[line] = self.file_churn.get(line, 0) + 1
+            if current_author:
+                author_map = self.author_files.setdefault(current_author, {})
+                author_map[line] = author_map.get(line, 0) + 1
 
     def refine(self) -> None:
         # authors

--- a/gitstats/report_creator.py
+++ b/gitstats/report_creator.py
@@ -77,6 +77,7 @@ class HTMLReportCreator(ReportCreator):
         self.create_files_html(data, path)
         self.create_lines_html(data, path)
         self.create_tags_html(data, path)
+        self.create_ownership_html(data, path)
 
         # Create AI Insights page if AI is enabled
         if hasattr(data, "ai_summaries") and data.ai_summaries:
@@ -840,6 +841,154 @@ class HTMLReportCreator(ReportCreator):
         f.write("</body></html>")
         f.close()
 
+    def _open_report_file(self, path: str, filename: str) -> Any:
+        """Open a report page for writing, confined to the report directory.
+
+        ``filename`` is always a hard-coded page name; resolving the target and
+        checking it stays under the report root guards against directory
+        traversal.
+        """
+        base = os.path.abspath(path)
+        target = os.path.abspath(os.path.join(base, filename))
+        if os.path.commonpath([base, target]) != base:
+            raise ValueError(f"Refusing to write outside report directory: {filename}")
+        return open(target, "w", encoding="utf-8")
+
+    def create_ownership_html(self, data: Any, path: str) -> None:
+        """Create the Code Ownership page.
+
+        Turns the per-author file-edit data into actionable views: files with a
+        single owner (bus-factor / knowledge-silo risk), how ownership is
+        concentrated per author, and the files touched by the most people
+        (coordination hotspots).
+        """
+        f = self._open_report_file(path, "ownership.html")
+        self.print_header(f)
+        self.print_nav(f)
+        f.write("<h1>Code Ownership</h1>")
+
+        author_files = getattr(data, "author_files", {})
+        if not isinstance(author_files, dict):
+            author_files = {}
+        ownership = compute_code_ownership(author_files)
+
+        if not ownership["files"]:
+            f.write(
+                '<div class="ownership-summary"><p>No ownership data available. '
+                "Ownership is derived from which files each author changes; try "
+                "analyzing a repository with commit history.</p></div>"
+            )
+            self.print_footer(f)
+            f.write("</body></html>")
+            f.close()
+            return
+
+        total = ownership["total_files"]
+        single = ownership["single_owner_files"]
+        single_pct = (100.0 * single / total) if total else 0.0
+
+        # Summary
+        f.write(
+            '<div class="ownership-summary">'
+            "<p>Ownership is measured by how many commits each author made to each "
+            "file. It highlights <strong>bus-factor risk</strong> (files only one "
+            "person has ever touched) and where knowledge is concentrated.</p>"
+            "<dl>"
+            "<dt>Files tracked</dt><dd>%d</dd>"
+            "<dt>Single-owner files</dt><dd>%d (%.1f%%)</dd>"
+            "<dt>Contributors</dt><dd>%d</dd>"
+            "</dl></div>" % (total, single, single_pct, len(ownership["authors"]))
+        )
+
+        # Bus-factor risk: single-owner files, most-changed first
+        f.write(html_header(2, "Bus Factor Risk — Single-Owner Files"))
+        f.write(
+            "<p><em>Files only one author has ever changed. The more a file has "
+            "changed, the more knowledge is at risk if that person leaves.</em></p>"
+        )
+        risk_files = [fs for fs in ownership["files"] if fs["contributors"] == 1]
+        if risk_files:
+            f.write(
+                '<table class="sortable" id="ownership-busfactor">'
+                "<tr><th>File</th><th>Sole owner</th><th>Commits</th></tr>"
+            )
+            for fs in risk_files[:50]:
+                f.write(
+                    "<tr><td>%s</td><td>%s</td><td>%d</td></tr>"
+                    % (html.escape(fs["path"]), html.escape(fs["owner"]), fs["edits"])
+                )
+            f.write("</table>")
+            if len(risk_files) > 50:
+                f.write(
+                    '<p class="moreauthors">Showing top 50 of %d single-owner files.</p>'
+                    % len(risk_files)
+                )
+        else:
+            f.write("<p>No single-owner files — every file has multiple contributors.</p>")
+
+        # Ownership concentration by author
+        f.write(html_header(2, "Ownership by Author"))
+        f.write(
+            "<p><em>Primary owner = the author with the most commits to a file. "
+            "Solely owned = files only that author has touched.</em></p>"
+        )
+        f.write(
+            '<table class="sortable" id="ownership-by-author">'
+            "<tr><th>Author</th><th>Files owned</th><th>Solely owned</th>"
+            "<th>Files touched</th></tr>"
+        )
+        for a in ownership["authors"][:25]:
+            f.write(
+                "<tr><td>%s</td><td>%d</td><td>%d</td><td>%d</td></tr>"
+                % (
+                    html.escape(a["author"]),
+                    a["files_owned"],
+                    a["files_solely_owned"],
+                    a["files_touched"],
+                )
+            )
+        f.write("</table>")
+        if len(ownership["authors"]) > 25:
+            f.write(
+                '<p class="moreauthors">Showing top 25 of %d contributors.</p>'
+                % len(ownership["authors"])
+            )
+
+        # Coordination hotspots: files with the most contributors
+        f.write(html_header(2, "Most Shared Files"))
+        f.write(
+            "<p><em>Files touched by the most people — shared code where changes "
+            "are most likely to need coordination.</em></p>"
+        )
+        shared = sorted(
+            (fs for fs in ownership["files"] if fs["contributors"] >= 2),
+            key=lambda x: (x["contributors"], x["edits"]),
+            reverse=True,
+        )
+        if shared:
+            f.write(
+                '<table class="sortable" id="ownership-shared">'
+                "<tr><th>File</th><th>Contributors</th><th>Primary owner</th>"
+                "<th>Owner share</th></tr>"
+            )
+            for fs in shared[:20]:
+                f.write(
+                    "<tr><td>%s</td><td>%d</td><td>%s</td><td>%.1f%%</td></tr>"
+                    % (
+                        html.escape(fs["path"]),
+                        fs["contributors"],
+                        html.escape(fs["owner"]),
+                        fs["ownership_pct"],
+                    )
+                )
+            f.write("</table>")
+        else:
+            f.write("<p>No files have more than one contributor yet.</p>")
+
+        self.print_footer(f)
+        f.write("</body></html>")
+        f.close()
+
     def create_ai_insights_html(self, data: Any, path: str) -> None:
         """
         Create a dedicated AI Insights page with all AI-generated summaries.
@@ -1098,6 +1247,7 @@ class HTMLReportCreator(ReportCreator):
             <li><a href="files.html">Files</a></li>
             <li><a href="lines.html">Lines</a></li>
             <li><a href="tags.html">Tags</a></li>
+            <li><a href="ownership.html">Code Ownership</a></li>
             {ai_link}
             </ul>
             <div class="nav-right">
@@ -1145,6 +1295,75 @@ class HTMLReportCreator(ReportCreator):
             </div>
         </div>
         """
+
+
+def compute_code_ownership(author_files: dict[str, dict[str, int]]) -> dict[str, Any]:
+    """Derive per-file ownership and per-author stats from author edit counts.
+
+    Args:
+        author_files: mapping of author -> file path -> number of commits that
+            author made touching the file.
+
+    Bot accounts (names ending in ``[bot]``) are excluded so ownership reflects
+    human contributors. Returns a dict with:
+        files:   per-file stats (path, edits, owner, owner_edits, ownership_pct,
+                 contributors), sorted by edits descending;
+        authors: per-author stats (author, files_owned, files_solely_owned,
+                 files_touched), sorted by files owned then files touched;
+        total_files, single_owner_files.
+    """
+    # Invert to file -> {author: edits}, dropping bots.
+    file_authors: dict[str, dict[str, int]] = {}
+    for author, files in author_files.items():
+        if author.endswith("[bot]"):
+            continue
+        for filepath, count in files.items():
+            file_authors.setdefault(filepath, {})[author] = count
+
+    files_stats: list[dict[str, Any]] = []
+    author_owned: dict[str, int] = {}
+    author_solely: dict[str, int] = {}
+    author_touched: dict[str, int] = {}
+    for filepath, authors in file_authors.items():
+        edits = sum(authors.values())
+        # Primary owner: most edits; ties broken alphabetically for determinism.
+        owner = max(sorted(authors), key=lambda a: authors[a])
+        contributors = len(authors)
+        files_stats.append(
+            {
+                "path": filepath,
+                "edits": edits,
+                "owner": owner,
+                "owner_edits": authors[owner],
+                "ownership_pct": round(100.0 * authors[owner] / edits, 1) if edits else 0.0,
+                "contributors": contributors,
+            }
+        )
+        author_owned[owner] = author_owned.get(owner, 0) + 1
+        if contributors == 1:
+            author_solely[owner] = author_solely.get(owner, 0) + 1
+        for a in authors:
+            author_touched[a] = author_touched.get(a, 0) + 1
+
+    files_stats.sort(key=lambda x: x["edits"], reverse=True)
+
+    authors_stats = [
+        {
+            "author": a,
+            "files_owned": author_owned.get(a, 0),
+            "files_solely_owned": author_solely.get(a, 0),
+            "files_touched": author_touched[a],
+        }
+        for a in author_touched
+    ]
+    authors_stats.sort(key=lambda x: (x["files_owned"], x["files_touched"]), reverse=True)
+
+    return {
+        "files": files_stats,
+        "authors": authors_stats,
+        "total_files": len(files_stats),
+        "single_owner_files": sum(1 for fs in files_stats if fs["contributors"] == 1),
+    }
 
 
 def html_header(level: int, text: str) -> str:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -347,6 +347,13 @@ def mock_data_collector():
         "Dockerfile": 2,
     }
 
+    # Code ownership: author -> file -> commits touching it
+    data.author_files = {
+        "Alice Smith": {"main.py": 10, "utils.py": 2, "solo_alice.py": 4},
+        "Bob Jones": {"main.py": 5, "utils.py": 8, "README.md": 8},
+        "Charlie Brown": {"main.py": 1},
+    }
+
     # Changes by date (lines)
     data.changes_by_date = {}
 

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -229,6 +229,27 @@ class TestGitDataCollectorIntegration:
         # File churn may be empty or non-empty depending on diff output
         assert isinstance(dc.file_churn, dict)
 
+    def test_collect_author_files(self, git_repo):
+        """The name-only pass records which files each author touched."""
+        dc = GitDataCollector()
+        prevdir = os.getcwd()
+        try:
+            os.chdir(git_repo)
+            dc.collect(git_repo)
+        finally:
+            os.chdir(prevdir)
+
+        # Alice: README.md + main.py (2 commits) + logo.png + .gitignore; Bob: utils.py
+        assert dc.author_files["Alice Smith"] == {
+            "README.md": 1,
+            "main.py": 2,
+            "logo.png": 1,
+            ".gitignore": 1,
+        }
+        assert dc.author_files["Bob Jones"] == {"utils.py": 1}
+        # file_churn comes from the same pass
+        assert dc.file_churn["main.py"] == 2
+
     def test_collect_changes_by_date(self, git_repo):
         dc = GitDataCollector()
         prevdir = os.getcwd()

--- a/tests/test_report_creator.py
+++ b/tests/test_report_creator.py
@@ -8,6 +8,7 @@ import pytest
 from gitstats.report_creator import (
     HTMLReportCreator,
     ReportCreator,
+    compute_code_ownership,
     get_keys_sorted_by_value_key,
     get_keys_sorted_by_values,
     html_header,
@@ -586,6 +587,7 @@ def test_create_all_pages(mock_data_collector, temp_dir):
         "files.html",
         "lines.html",
         "tags.html",
+        "ownership.html",
     ]
     for fname in expected_files:
         path = f"{temp_dir}/{fname}"
@@ -611,3 +613,92 @@ def test_create_copies_static_files(mock_data_collector, temp_dir):
 
     for fname in ("sortable.js", "chart.umd.min.js", "gitstats.css"):
         assert os.path.exists(f"{temp_dir}/{fname}"), f"Missing static file: {fname}"
+
+
+# ── Code ownership ───────────────────────────────────────────────────────
+
+
+def test_compute_code_ownership_stats():
+    author_files = {
+        "Alice": {"a.py": 3, "shared.py": 2},
+        "Bob": {"shared.py": 5, "b.py": 1},
+        "release[bot]": {"shared.py": 99},  # bots excluded
+    }
+    result = compute_code_ownership(author_files)
+
+    files = {fs["path"]: fs for fs in result["files"]}
+    # a.py: only Alice -> single owner
+    assert files["a.py"]["contributors"] == 1
+    assert files["a.py"]["owner"] == "Alice"
+    # shared.py: Alice 2 + Bob 5 -> Bob owns, bot ignored, 2 contributors
+    assert files["shared.py"]["contributors"] == 2
+    assert files["shared.py"]["owner"] == "Bob"
+    assert files["shared.py"]["edits"] == 7
+    assert files["shared.py"]["ownership_pct"] == round(100.0 * 5 / 7, 1)
+
+    assert result["total_files"] == 3
+    assert result["single_owner_files"] == 2  # a.py and b.py
+
+    authors = {a["author"]: a for a in result["authors"]}
+    assert "release[bot]" not in authors
+    assert authors["Alice"]["files_owned"] == 1  # a.py
+    assert authors["Alice"]["files_solely_owned"] == 1
+    assert authors["Bob"]["files_owned"] == 2  # shared.py + b.py
+    assert authors["Bob"]["files_touched"] == 2
+
+
+def test_compute_code_ownership_empty():
+    assert compute_code_ownership({}) == {
+        "files": [],
+        "authors": [],
+        "total_files": 0,
+        "single_owner_files": 0,
+    }
+
+
+def test_ownership_page_renders(mock_data_collector, temp_dir):
+    creator = HTMLReportCreator()
+    creator.create(mock_data_collector, temp_dir)
+
+    with open(f"{temp_dir}/ownership.html", encoding="utf-8") as f:
+        content = f.read()
+
+    assert "Code Ownership" in content
+    assert "Bus Factor Risk" in content
+    # solo_alice.py is only touched by Alice -> appears as a single-owner file
+    assert "solo_alice.py" in content
+    assert "Alice Smith" in content
+    assert "</html>" in content
+
+
+def test_ownership_page_empty_state(mock_data_collector, temp_dir):
+    mock_data_collector.author_files = {}
+    creator = HTMLReportCreator()
+    creator.create(mock_data_collector, temp_dir)
+
+    with open(f"{temp_dir}/ownership.html", encoding="utf-8") as f:
+        content = f.read()
+
+    assert "No ownership data available" in content
+    assert "</html>" in content
+
+
+def test_ownership_page_escapes_names(mock_data_collector, temp_dir):
+    mock_data_collector.author_files = {"Al<ice>": {"we<i>rd.py": 3}}
+    creator = HTMLReportCreator()
+    creator.create(mock_data_collector, temp_dir)
+
+    with open(f"{temp_dir}/ownership.html", encoding="utf-8") as f:
+        content = f.read()
+
+    assert "Al&lt;ice&gt;" in content
+    assert "we&lt;i&gt;rd.py" in content
+
+
+def test_open_report_file_confined_to_report_dir(temp_dir):
+    creator = HTMLReportCreator()
+    f = creator._open_report_file(temp_dir, "ownership.html")
+    f.close()
+    assert os.path.exists(f"{temp_dir}/ownership.html")
+    with pytest.raises(ValueError):
+        creator._open_report_file(temp_dir, "../escape.html")


### PR DESCRIPTION
Add an actionable code-ownership report derived from how many commits each
author makes to each file:

- Bus Factor Risk: files only one author has ever changed, ranked by how
  often they change (knowledge-silo / single-owner risk)
- Ownership by Author: files owned (primary contributor), solely owned, and
  total files touched per author
- Most Shared Files: files with the most contributors (coordination hotspots)

Data is collected in a single name-only git-log pass shared with file churn;
bot accounts are excluded. All tables are Top-N bounded so the page stays
small and fast even on large repositories, with no inlined data or JS.

Includes a pure compute_code_ownership() helper with unit tests covering the
ownership math, bot exclusion, empty state, HTML escaping, and path safety.

<!-- readthedocs-preview gitstats start -->
----
📚 Documentation preview 📚: https://gitstats--252.org.readthedocs.build/

<!-- readthedocs-preview gitstats end -->