### PR TITLE
feat: limit authors per tag to improve performance

### DIFF
--- a/docs/source/configuration.rst
+++ b/docs/source/configuration.rst
@@ -9,6 +9,7 @@ You can create a ``gitstats.conf`` file in the current directory to customize th
 * ``style`` - CSS stylesheet for the generated report. Default: ``gitstats.css``.
 * ``max_authors`` - Maximum number of authors to list in "Authors". Default: ``20``.
 * ``authors_top`` - Number of top authors to highlight. Default: ``5``.
+* ``max_tags_authors`` - Maximum number of authors to display per tag in "Tags" page. Set to ``-1`` to show all authors (no limit). Default: ``50``.
 * ``commit_begin`` - Start of commit range (empty = include all commits). For example, ``10`` for last 10 commits. Default: ``""`` (empty).
 * ``commit_end`` - End of commit range. Default: ``HEAD``.
 * ``linear_linestats`` - Enable linear history for line statistics (``1`` = enabled, ``0`` = disabled). Default: ``1``.

--- a/gitstats.conf
+++ b/gitstats.conf
@@ -14,6 +14,12 @@ max_authors = 20
 # Number of top authors to highlight in monthly/yearly breakdowns
 authors_top = 5
 
+# Maximum number of authors to display per tag in "Tags" page
+# When a tag has more authors than this limit, the remaining authors are summarized
+# Example: "author1 (10), author2 (8), ... and 45 more authors"
+# Set to -1 to show all authors (no limit)
+max_tags_authors = 50
+
 # Start of commit range (empty = include all commits). For example, 10 for last 10 commits
 commit_begin =
 

--- a/gitstats/__init__.py
+++ b/gitstats/__init__.py
@@ -18,6 +18,7 @@ DEFAULT_CONFIG: dict[str, Any] = {
     "max_ext_length": 10,  # Maximum length of file extensions shown in statistics.
     "style": "gitstats.css",  # CSS stylesheet for the generated report.
     "max_authors": 20,  # Maximum number of authors to list in "Authors".
+    "max_tags_authors": 50,  # Maximum number of authors per tag in "Tags" page.
     "authors_top": 5,  # Number of top authors to highlight.
     "commit_begin": "",  # Start of commit range (empty = include all commits).
     "commit_end": "HEAD",  # End of commit range (default: HEAD).

--- a/gitstats/report_creator.py
+++ b/gitstats/report_creator.py
@@ -843,11 +843,21 @@ class HTMLReportCreator(ReportCreator):
             el[1]
             for el in sorted([(el[1]["date"], el[0]) for el in data.tags.items()], reverse=True)
         ]
+        max_tags_authors = load_config()["max_tags_authors"]
         for tag in tags_sorted_by_date_desc:
             authorinfo = []
             self.authors_by_commits = get_keys_sorted_by_values(data.tags[tag]["authors"])
-            for i in reversed(self.authors_by_commits):
-                authorinfo.append("%s (%d)" % (i, data.tags[tag]["authors"][i]))
+            authors_reversed = list(reversed(self.authors_by_commits))
+            # max_tags_authors < 0 (e.g., -1) means no limit
+            if max_tags_authors >= 0 and len(authors_reversed) > max_tags_authors:
+                authors_shown = authors_reversed[:max_tags_authors]
+                remaining = len(authors_reversed) - max_tags_authors
+                for i in authors_shown:
+                    authorinfo.append("%s (%d)" % (i, data.tags[tag]["authors"][i]))
+                authorinfo.append("<em>and %d more authors</em>" % remaining)
+            else:
+                for i in authors_reversed:
+                    authorinfo.append("%s (%d)" % (i, data.tags[tag]["authors"][i]))
             f.write(
                 "<tr><td>%s</td><td>%s</td><td>%d</td><td>%s</td></tr>"
                 % (

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -34,6 +34,7 @@ def test_default_config_keys():
         "max_ext_length",
         "style",
         "max_authors",
+        "max_tags_authors",
         "authors_top",
         "commit_begin",
         "commit_end",


### PR DESCRIPTION
## Problem

The Tags page generates excessive HTML when a release tag has hundreds of authors (e.g., CPython), causing slow page loading and rendering.

## Solution

Added a new `max_tags_authors` config option (default: `50`) that limits the number of authors displayed per tag. When a tag exceeds the limit, the remaining authors are summarized as `and N more authors`.

| Value  | Behavior |
|--------|----------|
| `50` (default) | Show up to 50 authors per tag |
| `-1` | Unlimited — show all authors |
| `0` | Show zero authors |

### Files changed

- `gitstats/__init__.py` — Added `max_tags_authors: 50` to `DEFAULT_CONFIG`
- `gitstats/report_creator.py` — Added limiting logic in `create_tags_html`
- `gitstats.conf` — Added config option with documentation comment
- `docs/source/configuration.rst` — Added documentation entry