### PR TITLE
feat: add max_authors_list config to limit author list on Authors page

### DIFF
--- a/gitstats.conf
+++ b/gitstats.conf
@@ -20,6 +20,10 @@ authors_top = 5
 # Set to -1 to show all authors (no limit)
 max_tags_authors = 50
 
+# Maximum number of "other" authors listed by name in the "These didn't make it to the top"
+# paragraph on the Authors page. When exceeded, the rest are summarized as "and N more".
+max_authors_list = 50
+
 # Start of commit range (empty = include all commits). For example, 10 for last 10 commits
 commit_begin =
 

--- a/gitstats/__init__.py
+++ b/gitstats/__init__.py
@@ -19,6 +19,7 @@ DEFAULT_CONFIG: dict[str, Any] = {
     "style": "gitstats.css",  # CSS stylesheet for the generated report.
     "max_authors": 20,  # Maximum number of authors to list in "Authors".
     "max_tags_authors": 50,  # Maximum number of authors per tag in "Tags" page.
+    "max_authors_list": 50,  # Maximum number of "other" authors listed by name on the Authors page.
     "authors_top": 5,  # Number of top authors to highlight.
     "commit_begin": "",  # Start of commit range (empty = include all commits).
     "commit_end": "HEAD",  # End of commit range (default: HEAD).

--- a/gitstats/report_creator.py
+++ b/gitstats/report_creator.py
@@ -514,11 +514,20 @@ class HTMLReportCreator(ReportCreator):
         allauthors = data.get_authors()
         if len(allauthors) > load_config()["max_authors"]:
             rest = allauthors[load_config()["max_authors"] :]
-            f.write(
-                '<p class="moreauthors">These didn\'t make it to the top: {}</p>'.format(
-                    ", ".join(rest)
+            max_list = load_config()["max_authors_list"]
+            if len(rest) > max_list:
+                shown = ", ".join(rest[:max_list])
+                more = len(rest) - max_list
+                f.write(
+                    f'<p class="moreauthors">These didn\'t make it to the top:'
+                    f" {shown}<em>, and {more} more authors</em></p>"
                 )
-            )
+            else:
+                f.write(
+                    '<p class="moreauthors">These didn\'t make it to the top: {}</p>'.format(
+                        ", ".join(rest)
+                    )
+                )
 
         # Build per-author time series data for Chart.js
         time_labels, loc_datasets, cba_datasets = self._build_author_time_series(data)

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -35,6 +35,7 @@ def test_default_config_keys():
         "style",
         "max_authors",
         "max_tags_authors",
+        "max_authors_list",
         "authors_top",
         "commit_begin",
         "commit_end",
@@ -62,6 +63,7 @@ def test_default_config_types():
     """Verify config values have correct types."""
     assert isinstance(DEFAULT_CONFIG["max_domains"], int)
     assert isinstance(DEFAULT_CONFIG["max_authors"], int)
+    assert isinstance(DEFAULT_CONFIG["max_authors_list"], int)
     assert isinstance(DEFAULT_CONFIG["ai_enabled"], bool)
     assert isinstance(DEFAULT_CONFIG["processes"], int)
     assert isinstance(DEFAULT_CONFIG["ai_language"], str)


### PR DESCRIPTION
When a repository has many contributors (e.g., git.git with thousands), the 'These didn't make it to the top' paragraph on the Authors page previously listed ALL remaining author names, generating a massive HTML string and causing performance issues.

- Add max_authors_list config option (default: 50) to control how many 'other' authors are listed by name
- When exceeded, show only the first max_authors_list names followed by 'and N more authors'
- Update DEFAULT_CONFIG, gitstats.conf, and tests

<!-- readthedocs-preview gitstats start -->
----
📚 Documentation preview 📚: https://gitstats--255.org.readthedocs.build/

<!-- readthedocs-preview gitstats end -->