### PR TITLE
chore: Remove hadolint installation commands from pre-commit

### DIFF
--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -6,8 +6,3 @@ on:
 jobs:
   pre-commit:
     uses: shenxianpeng/.github/.github/workflows/pre-commit.yml@main
-    with:
-      commands: |
-        wget -O hadolint https://github.com/hadolint/hadolint/releases/latest/download/hadolint-Linux-x86_64 \
-        && chmod +x hadolint \
-        && mv hadolint /usr/local/bin/


### PR DESCRIPTION
Removed wget commands for downloading and installing hadolint.

<!-- readthedocs-preview gitstats start -->
----
📚 Documentation preview 📚: https://gitstats--258.org.readthedocs.build/

<!-- readthedocs-preview gitstats end -->