### PR TITLE
ci: pin workflow actions to commit SHAs

### DIFF
--- a/.github/workflows/gallery.yml
+++ b/.github/workflows/gallery.yml
@@ -26,13 +26,13 @@ jobs:
           - { id: homebrew,   name: "Homebrew",     url: "Homebrew/brew"         }
 
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
           # setuptools-scm needs tags to derive the version shown in reports
           fetch-depth: 0
           fetch-tags: true
 
-      - uses: actions/setup-python@v7
+      - uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7
         with:
           python-version: "3.10"
 
@@ -47,7 +47,7 @@ jobs:
           gitstats /tmp/repo "report"
 
       - name: Upload Artifact
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: report-${{ matrix.repo.id }}
           path: report/
@@ -58,9 +58,9 @@ jobs:
     permissions:
       contents: write
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
 
-      - uses: actions/download-artifact@v8
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
         with:
           pattern: report-*
           path: gallery
@@ -88,7 +88,7 @@ jobs:
         run: python scripts/generate_gallery_index.py gallery
 
       - name: Deploy to GitHub Pages
-        uses: peaceiris/actions-gh-pages@84c30a85c19949d7eee79c4ff27748b70285e453
+        uses: peaceiris/actions-gh-pages@84c30a85c19949d7eee79c4ff27748b70285e453 # v4.1.0
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           publish_dir: ./gallery

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -14,12 +14,12 @@ jobs:
 
     steps:
     - name: Checkout Code
-      uses: actions/checkout@v7
+      uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
       with:
         fetch-depth: 0 # get all history.
 
     - name: Set up Python 3.10
-      uses: actions/setup-python@v7
+      uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7
       with:
         python-version: "3.10"
 
@@ -35,7 +35,7 @@ jobs:
         uv run nox -s build
 
     - name: Save GitStats Report
-      uses: actions/upload-artifact@v7
+      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
       with:
         name: test-report
         path: test-report

--- a/.github/workflows/publish-pypi.yml
+++ b/.github/workflows/publish-pypi.yml
@@ -23,12 +23,12 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v7
+    - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
       # use fetch --all for setuptools_scm to work
       with:
         fetch-depth: 0
     - name: Set up Python
-      uses: actions/setup-python@v7
+      uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7
       with:
         python-version: '3.x'
     - name: Install dependencies

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -11,6 +11,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       # Draft your next Release notes as Pull Requests are merged into the default branch
-      - uses: release-drafter/release-drafter@v7
+      - uses: release-drafter/release-drafter@34d80673e067bdc0c24568d3af899c216adcfaa9 # v7
         with:
           config-name: github:shenxianpeng/.github:/.github/release-drafter.yml

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -24,12 +24,12 @@ jobs:
 
     steps:
     - name: Checkout Code
-      uses: actions/checkout@v7
+      uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
       with:
         fetch-depth: 0  # full history for gitstats integration
 
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v7
+      uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7
       with:
         python-version: ${{ matrix.python-version }}
         cache: 'pip'
@@ -61,7 +61,7 @@ jobs:
 
     - name: Upload report artifact
       if: ${{ matrix.python-version == '3.10' }}
-      uses: actions/upload-artifact@v7
+      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
       with:
         name: test-report-${{ matrix.os }}
         path: test-report
@@ -70,10 +70,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Checkout Code
-      uses: actions/checkout@v7
+      uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
 
     - name: Set up Python 3.12
-      uses: actions/setup-python@v7
+      uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7
       with:
         python-version: 3.12
         cache: 'pip'


### PR DESCRIPTION
## Summary

Pins every in-repository third-party GitHub Action reference to a full commit SHA, retaining a human-readable version comment.

## Details

- Updated checkout, setup-python, upload-artifact, download-artifact, and release-drafter across 	.github/workflows/
- Added the missing # v4.1.0 comment to the existing gh-pages pin in gallery.yml`n- Left the reusable workflows from shenxianpeng/.github unchanged because issue #260 marks them out of scope
- Resolved the current setup-python@v7 and download-artifact@v8 tags at implementation time; the issue table listed older tag versions, so those old SHAs would not have described the current workflow

## Validation

- git diff --check`n- Python YAML parsing for every .github/workflows/*.yml`n- Confirmed g 'uses:.*@[vV][0-9]' .github/workflows returns no matches
- ctionlint is not installed in this checkout

Closes #260

<!-- readthedocs-preview gitstats start -->
----
📚 Documentation preview 📚: https://gitstats--262.org.readthedocs.build/

<!-- readthedocs-preview gitstats end -->