### PR TITLE
refactor: decompose GitDataCollector.collect() into single-purpose phases

### DIFF
--- a/gitstats/main.py
+++ b/gitstats/main.py
@@ -190,15 +190,35 @@ class DataCollector:
 
 class GitDataCollector(DataCollector):
     def collect(self, repo_dir):
+        """Collect all statistics from the repository.
+
+        Each phase below owns one slice of the data model; the only value
+        passed between them is the author-alias mapping, which later phases
+        need to attribute work to canonical identities.
+        """
         DataCollector.collect(self, repo_dir)
 
         self.total_authors += int(
             get_pipe_output(["git shortlog -s {}".format(get_log_range("HEAD", False)), "wc -l"])
         )
-        # self.total_lines = int(getoutput('git-ls-files -z |xargs -0 cat |wc -l'))
 
-        # tags
-        # Only include tags that are reachable within the commit range
+        self._collect_tags()
+        email_to_latest, author_to_email = self._collect_commit_stats()
+        name_to_canonical = self._merge_author_aliases(email_to_latest, author_to_email)
+        self._collect_files_by_stamp()
+        self._collect_extensions()
+        self._collect_line_stats()
+        self._collect_per_author_line_stats(name_to_canonical)
+        self._collect_file_churn_and_ownership(name_to_canonical)
+
+    # ── collection phases ────────────────────────────────────────────────
+
+    def _collect_tags(self) -> None:
+        """Populate ``tags`` with each tag's date, commit count and authors.
+
+        Only tags whose commit is reachable within the configured commit range
+        are included.
+        """
         log_range = get_log_range("HEAD", False)
         tag_commits = get_pipe_output([f"git rev-list {log_range}"]).strip().split("\n")
         tag_commits_set = set(tag_commits) if tag_commits[0] else set()
@@ -232,7 +252,6 @@ class GitDataCollector(DataCollector):
 
         # collect info on tags, starting from latest
         # Only collect statistics for commits within our range
-        log_range = get_log_range("HEAD", False)
         tags_sorted_by_date_desc = [
             el[1]
             for el in sorted([(el[1]["date"], el[0]) for el in self.tags.items()], reverse=True)
@@ -260,7 +279,12 @@ class GitDataCollector(DataCollector):
                 self.tags[tag]["commits"] += commits
                 self.tags[tag]["authors"][author] = commits
 
-        # Collect revision statistics
+    def _collect_commit_stats(self) -> tuple[dict[str, tuple[int, str]], dict[str, str]]:
+        """Walk every commit, accumulating activity, domain and author stats.
+
+        Returns the two mappings needed to resolve author identities:
+        ``email -> (latest stamp, author name)`` and ``author name -> email``.
+        """
         # Outputs "<stamp> <date> <time> <timezone> <author> '<' <mail> '>'"
         lines = get_pipe_output(
             [
@@ -307,17 +331,7 @@ class GitDataCollector(DataCollector):
             if self.first_commit_stamp == 0 or stamp < self.first_commit_stamp:
                 self.first_commit_stamp = stamp
 
-            # activity
-            # hour
-            hour = date.hour
-            self.activity_by_hour_of_day[hour] = self.activity_by_hour_of_day.get(hour, 0) + 1
-            # most active hour?
-            if self.activity_by_hour_of_day[hour] > self.activity_by_hour_of_day_busiest:
-                self.activity_by_hour_of_day_busiest = self.activity_by_hour_of_day[hour]
-
-            # day of week
-            day = date.weekday()
-            self.activity_by_day_of_week[day] = self.activity_by_day_of_week.get(day, 0) + 1
+            self._record_activity(date)
 
             # domain stats
             if domain not in self.domains:
@@ -325,73 +339,103 @@ class GitDataCollector(DataCollector):
             # commits
             self.domains[domain]["commits"] = self.domains[domain].get("commits", 0) + 1
 
-            # hour of week
-            if day not in self.activity_by_hour_of_week:
-                self.activity_by_hour_of_week[day] = {}
-            self.activity_by_hour_of_week[day][hour] = (
-                self.activity_by_hour_of_week[day].get(hour, 0) + 1
-            )
-            # most active hour?
-            if self.activity_by_hour_of_week[day][hour] > self.activity_by_hour_of_week_busiest:
-                self.activity_by_hour_of_week_busiest = self.activity_by_hour_of_week[day][hour]
-
-            # month of year
-            month = date.month
-            self.activity_by_month_of_year[month] = self.activity_by_month_of_year.get(month, 0) + 1
-
-            # yearly/weekly activity
-            yyw = date.strftime("%Y-%W")
-            self.activity_by_year_week[yyw] = self.activity_by_year_week.get(yyw, 0) + 1
-            if self.activity_by_year_week_peak < self.activity_by_year_week[yyw]:
-                self.activity_by_year_week_peak = self.activity_by_year_week[yyw]
-
-            # author stats
-            if author not in self.authors:
-                self.authors[author] = {}
-            # commits, note again that commits may be in any date order because of cherry-picking and patches
-            if "last_commit_stamp" not in self.authors[author]:
-                self.authors[author]["last_commit_stamp"] = stamp
-            if stamp > self.authors[author]["last_commit_stamp"]:
-                self.authors[author]["last_commit_stamp"] = stamp
-            if "first_commit_stamp" not in self.authors[author]:
-                self.authors[author]["first_commit_stamp"] = stamp
-            if stamp < self.authors[author]["first_commit_stamp"]:
-                self.authors[author]["first_commit_stamp"] = stamp
-
-            # author of the month/year
-            yymm = date.strftime("%Y-%m")
-            if yymm in self.author_of_month:
-                self.author_of_month[yymm][author] = self.author_of_month[yymm].get(author, 0) + 1
-            else:
-                self.author_of_month[yymm] = {}
-                self.author_of_month[yymm][author] = 1
-            self.commits_by_month[yymm] = self.commits_by_month.get(yymm, 0) + 1
-
-            yy = date.year
-            if yy in self.author_of_year:
-                self.author_of_year[yy][author] = self.author_of_year[yy].get(author, 0) + 1
-            else:
-                self.author_of_year[yy] = {}
-                self.author_of_year[yy][author] = 1
-            self.commits_by_year[yy] = self.commits_by_year.get(yy, 0) + 1
-
-            # authors: active days
-            yymmdd = date.strftime("%Y-%m-%d")
-            if "last_active_day" not in self.authors[author]:
-                self.authors[author]["last_active_day"] = yymmdd
-                self.authors[author]["active_days"] = set([yymmdd])
-            elif yymmdd != self.authors[author]["last_active_day"]:
-                self.authors[author]["last_active_day"] = yymmdd
-                self.authors[author]["active_days"].add(yymmdd)
-
-            # project: active days
-            if yymmdd != self.last_active_day:
-                self.last_active_day = yymmdd
-                self.active_days.add(yymmdd)
+            self._record_author_commit(author, stamp, date)
 
             # timezone
             self.commits_by_timezone[timezone] = self.commits_by_timezone.get(timezone, 0) + 1
 
+        return email_to_latest, author_to_email
+
+    def _record_activity(self, date: datetime.datetime) -> None:
+        """Accumulate the time-of-commit histograms for a single commit."""
+        # hour
+        hour = date.hour
+        self.activity_by_hour_of_day[hour] = self.activity_by_hour_of_day.get(hour, 0) + 1
+        # most active hour?
+        if self.activity_by_hour_of_day[hour] > self.activity_by_hour_of_day_busiest:
+            self.activity_by_hour_of_day_busiest = self.activity_by_hour_of_day[hour]
+
+        # day of week
+        day = date.weekday()
+        self.activity_by_day_of_week[day] = self.activity_by_day_of_week.get(day, 0) + 1
+
+        # hour of week
+        if day not in self.activity_by_hour_of_week:
+            self.activity_by_hour_of_week[day] = {}
+        self.activity_by_hour_of_week[day][hour] = (
+            self.activity_by_hour_of_week[day].get(hour, 0) + 1
+        )
+        # most active hour?
+        if self.activity_by_hour_of_week[day][hour] > self.activity_by_hour_of_week_busiest:
+            self.activity_by_hour_of_week_busiest = self.activity_by_hour_of_week[day][hour]
+
+        # month of year
+        month = date.month
+        self.activity_by_month_of_year[month] = self.activity_by_month_of_year.get(month, 0) + 1
+
+        # yearly/weekly activity
+        yyw = date.strftime("%Y-%W")
+        self.activity_by_year_week[yyw] = self.activity_by_year_week.get(yyw, 0) + 1
+        if self.activity_by_year_week_peak < self.activity_by_year_week[yyw]:
+            self.activity_by_year_week_peak = self.activity_by_year_week[yyw]
+
+    def _record_author_commit(self, author: str, stamp: int, date: datetime.datetime) -> None:
+        """Accumulate per-author and per-period stats for a single commit."""
+        # author stats
+        if author not in self.authors:
+            self.authors[author] = {}
+        # commits, note again that commits may be in any date order because of cherry-picking and patches
+        if "last_commit_stamp" not in self.authors[author]:
+            self.authors[author]["last_commit_stamp"] = stamp
+        if stamp > self.authors[author]["last_commit_stamp"]:
+            self.authors[author]["last_commit_stamp"] = stamp
+        if "first_commit_stamp" not in self.authors[author]:
+            self.authors[author]["first_commit_stamp"] = stamp
+        if stamp < self.authors[author]["first_commit_stamp"]:
+            self.authors[author]["first_commit_stamp"] = stamp
+
+        # author of the month/year
+        yymm = date.strftime("%Y-%m")
+        if yymm in self.author_of_month:
+            self.author_of_month[yymm][author] = self.author_of_month[yymm].get(author, 0) + 1
+        else:
+            self.author_of_month[yymm] = {}
+            self.author_of_month[yymm][author] = 1
+        self.commits_by_month[yymm] = self.commits_by_month.get(yymm, 0) + 1
+
+        yy = date.year
+        if yy in self.author_of_year:
+            self.author_of_year[yy][author] = self.author_of_year[yy].get(author, 0) + 1
+        else:
+            self.author_of_year[yy] = {}
+            self.author_of_year[yy][author] = 1
+        self.commits_by_year[yy] = self.commits_by_year.get(yy, 0) + 1
+
+        # authors: active days
+        yymmdd = date.strftime("%Y-%m-%d")
+        if "last_active_day" not in self.authors[author]:
+            self.authors[author]["last_active_day"] = yymmdd
+            self.authors[author]["active_days"] = set([yymmdd])
+        elif yymmdd != self.authors[author]["last_active_day"]:
+            self.authors[author]["last_active_day"] = yymmdd
+            self.authors[author]["active_days"].add(yymmdd)
+
+        # project: active days
+        if yymmdd != self.last_active_day:
+            self.last_active_day = yymmdd
+            self.active_days.add(yymmdd)
+
+    def _merge_author_aliases(
+        self,
+        email_to_latest: dict[str, tuple[int, str]],
+        author_to_email: dict[str, str],
+    ) -> dict[str, str]:
+        """Fold authors that share an email into one canonical identity.
+
+        Merges the alias entries in ``authors``, the per-period author dicts and
+        the tag author dicts, then returns the ``alias -> canonical`` mapping so
+        later phases can attribute their data to the same identities.
+        """
         # Build canonical name mapping: merge authors that share the same email
         # (same person who committed with different name/email configurations)
         email_to_canonical = {email: name for email, (_, name) in email_to_latest.items()}
@@ -449,6 +493,10 @@ class GitDataCollector(DataCollector):
         # Update total_authors to reflect merged identities
         self.total_authors = len(self.authors)
 
+        return name_to_canonical
+
+    def _collect_files_by_stamp(self) -> None:
+        """Record the file count of every revision, using the blob cache."""
         # outputs "<stamp> <files>" for each revision
         revlines = (
             get_pipe_output(
@@ -498,6 +546,8 @@ class GitDataCollector(DataCollector):
             except ValueError:
                 logger.warning(f'Failed to parse line "{line}"')
 
+    def _collect_extensions(self) -> None:
+        """Count files, total size and lines per file extension at HEAD."""
         # extensions and size of files
         lines = get_pipe_output(
             ["git ls-tree -r -l -z {}".format(get_commit_range("HEAD", end_only=True))]
@@ -552,6 +602,12 @@ class GitDataCollector(DataCollector):
             self.cache["lines_in_blob"][blob_id] = linecount
             self.extensions[ext]["lines"] += self.cache["lines_in_blob"][blob_id]
 
+    def _collect_line_stats(self) -> None:
+        """Record lines added/removed over time (``changes_by_date``).
+
+        Computed on a linear history when ``linear_linestats`` is enabled, since
+        lines-of-code over time is better measured along the mainline.
+        """
         # line statistics
         # outputs:
         #  N files changed, N insertions (+), N deletions(-)
@@ -574,17 +630,17 @@ class GitDataCollector(DataCollector):
         inserted = 0
         deleted = 0
         total_lines = 0
-        author = None
         for line in lines:
             if len(line) == 0:
                 continue
 
-            # <stamp> <author>
+            # <stamp> <author>; only the stamp matters here, the author is
+            # attributed in _collect_per_author_line_stats
             if re.search("files? changed", line) is None:
                 pos = line.find(" ")
                 if pos != -1:
                     try:
-                        (stamp, author) = (int(line[:pos]), line[pos + 1 :])
+                        stamp = int(line[:pos])
                         self.changes_by_date[stamp] = {
                             "files": files,
                             "ins": inserted,
@@ -627,17 +683,18 @@ class GitDataCollector(DataCollector):
                 else:
                     logger.warning(f'Failed to handle line "{line}"')
                     (files, inserted, deleted) = (0, 0, 0)
-                # self.changes_by_date[stamp] = { 'files': files, 'ins': inserted, 'del': deleted }
         self.total_lines += total_lines
 
-        # Per-author statistics
+    def _collect_per_author_line_stats(self, name_to_canonical: dict[str, str]) -> None:
+        """Record each author's commits and line counts over time.
 
+        Unlike :meth:`_collect_line_stats` this never uses ``--first-parent``:
+        every commit must be walked to know who committed what, not just the
+        mainline.
+        """
         # defined for stamp, author only if author committed at this timestamp.
         self.changes_by_date_by_author = {}  # stamp -> author -> lines_added
 
-        # Similar to the above, but never use --first-parent
-        # (we need to walk through every commit to know who
-        # committed what, not just through mainline)
         lines = get_pipe_output(
             [
                 'git log --shortstat --date-order --pretty=format:"%at %aN" {}'.format(
@@ -646,7 +703,6 @@ class GitDataCollector(DataCollector):
             ]
         ).split("\n")
         lines.reverse()
-        files = 0
         inserted = 0
         deleted = 0
         author = None
@@ -689,7 +745,7 @@ class GitDataCollector(DataCollector):
                         self.changes_by_date_by_author[stamp][author]["commits"] = self.authors[
                             author
                         ]["commits"]
-                        files, inserted, deleted = 0, 0, 0
+                        inserted, deleted = 0, 0
                     except ValueError:
                         logger.warning(f'Unexpected line "{line}"')
                 else:
@@ -698,17 +754,22 @@ class GitDataCollector(DataCollector):
                 numbers = get_stat_summary_counts(line)
 
                 if len(numbers) == 3:
-                    (files, inserted, deleted) = [int(el) for el in numbers]
+                    # the file count is unused here; only line deltas matter
+                    (_, inserted, deleted) = [int(el) for el in numbers]
                 else:
                     logger.warning(f'Failed to handle line "{line}"')
-                    (files, inserted, deleted) = (0, 0, 0)
+                    (inserted, deleted) = (0, 0)
 
-        # Single name-only pass drives two metrics:
-        #   * file_churn   -> how many commits touched each file
-        #   * author_files -> which files each author touches (code ownership)
-        # Each commit is prefixed with a "COMMIT:<author>" marker line; the lines
-        # that follow are the file paths changed by that commit. Authors are
-        # resolved to their canonical identity so aliases merge here directly.
+    def _collect_file_churn_and_ownership(self, name_to_canonical: dict[str, str]) -> None:
+        """Record how often each file changes and who changes it.
+
+        A single name-only pass drives two metrics:
+        ``file_churn`` (commits touching each file) and ``author_files``
+        (which files each author touches, for code ownership). Each commit is
+        prefixed with a ``COMMIT:<author>`` marker line; the lines that follow
+        are the file paths changed by that commit. Authors are resolved to their
+        canonical identity so aliases merge here directly.
+        """
         churn_output = get_pipe_output(
             ['git log --format="COMMIT:%aN" --name-only {}'.format(get_log_range("HEAD", False))]
         )

--- a/gitstats/main.py
+++ b/gitstats/main.py
@@ -74,6 +74,19 @@ def parallel_map_with_fallback(func, items):
         return [func(item) for item in items]
 
 
+def _merge_period_aliases(
+    period_authors: dict[str, int], name_to_canonical: dict[str, str]
+) -> None:
+    """Fold aliased authors into their canonical name within one period.
+
+    ``period_authors`` maps author -> commit count for a single month or year
+    and is updated in place.
+    """
+    for alias, canonical in name_to_canonical.items():
+        if alias in period_authors:
+            period_authors[canonical] = period_authors.get(canonical, 0) + period_authors.pop(alias)
+
+
 class DataCollector:
     """Manages data collection from a revision control repository."""
 
@@ -473,14 +486,11 @@ class GitDataCollector(DataCollector):
             if "last_active_day" in aa:
                 ca["last_active_day"] = max(ca.get("last_active_day", ""), aa["last_active_day"])
 
-        # Merge aliases in time-based author dicts
-        for period_dict in (self.author_of_month, self.author_of_year):
-            for period in period_dict:
-                for alias, canonical in name_to_canonical.items():
-                    if alias in period_dict[period]:
-                        period_dict[period][canonical] = period_dict[period].get(
-                            canonical, 0
-                        ) + period_dict[period].pop(alias)
+        # Merge aliases in time-based author dicts. The two dicts are keyed
+        # differently (month string vs. year int) but their values share one
+        # shape, so the merge works on the inner author->commits dicts.
+        for period_authors in (*self.author_of_month.values(), *self.author_of_year.values()):
+            _merge_period_aliases(period_authors, name_to_canonical)
 
         # Merge aliases in tag author dicts
         for tag in self.tags:

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -1,5 +1,6 @@
 """Tests for gitstats.main – DataCollector, parameter parsing, and integration with real git repos."""
 
+import datetime
 import os
 from unittest.mock import patch
 
@@ -400,6 +401,151 @@ class TestGitDataCollectorIntegration:
         # Should be exactly one entry for Alice
         assert "Alice Smith" in dc.authors
         assert dc.authors["Alice Smith"]["commits"] > 0
+
+
+# ── collect() phases (unit-testable without a repository) ────────────────
+
+
+class TestCollectPhases:
+    """Each collection phase is exercised on its own, no git required."""
+
+    def test_record_activity_accumulates_histograms(self):
+        dc = GitDataCollector()
+        # Wed 2024-05-08 14:xx  (weekday 2), plus a second commit the same hour
+        d1 = datetime.datetime(2024, 5, 8, 14, 30)
+        d2 = datetime.datetime(2024, 5, 8, 14, 45)
+        d3 = datetime.datetime(2024, 5, 9, 9, 0)  # Thu, different hour
+
+        for d in (d1, d2, d3):
+            dc._record_activity(d)
+
+        assert dc.activity_by_hour_of_day == {14: 2, 9: 1}
+        assert dc.activity_by_day_of_week == {2: 2, 3: 1}
+        assert dc.activity_by_hour_of_week[2][14] == 2
+        assert dc.activity_by_month_of_year == {5: 3}
+        assert dc.activity_by_hour_of_day_busiest == 2
+        assert dc.activity_by_hour_of_week_busiest == 2
+        # all three fall in the same calendar week
+        assert dc.activity_by_year_week == {d1.strftime("%Y-%W"): 3}
+        assert dc.activity_by_year_week_peak == 3
+
+    def test_record_author_commit_tracks_span_and_active_days(self):
+        dc = GitDataCollector()
+        early = datetime.datetime(2024, 1, 10, 9, 0)
+        late = datetime.datetime(2024, 3, 20, 9, 0)
+
+        # deliberately out of order: stamps may arrive in any order
+        dc._record_author_commit("Ann", int(late.timestamp()), late)
+        dc._record_author_commit("Ann", int(early.timestamp()), early)
+        dc._record_author_commit("Bo", int(late.timestamp()), late)
+
+        ann = dc.authors["Ann"]
+        assert ann["first_commit_stamp"] == int(early.timestamp())
+        assert ann["last_commit_stamp"] == int(late.timestamp())
+        assert ann["active_days"] == {"2024-01-10", "2024-03-20"}
+        assert dc.commits_by_month == {"2024-03": 2, "2024-01": 1}
+        assert dc.commits_by_year == {2024: 3}
+        assert dc.author_of_month["2024-03"] == {"Ann": 1, "Bo": 1}
+        assert dc.active_days == {"2024-01-10", "2024-03-20"}
+
+    def test_merge_author_aliases_folds_shared_email(self):
+        """Two names on one email collapse into the most recent name."""
+        dc = GitDataCollector()
+        dc.authors = {
+            "old name": {
+                "commits": 2,
+                "lines_added": 10,
+                "lines_removed": 1,
+                "first_commit_stamp": 100,
+                "last_commit_stamp": 200,
+                "active_days": {"2024-01-01"},
+                "last_active_day": "2024-01-01",
+            },
+            "New Name": {
+                "commits": 3,
+                "lines_added": 5,
+                "lines_removed": 2,
+                "first_commit_stamp": 300,
+                "last_commit_stamp": 400,
+                "active_days": {"2024-02-02"},
+                "last_active_day": "2024-02-02",
+            },
+        }
+        dc.author_of_month = {"2024-01": {"old name": 2}, "2024-02": {"New Name": 3}}
+        dc.author_of_year = {2024: {"old name": 2, "New Name": 3}}
+        dc.tags = {"v1": {"authors": {"old name": 2, "New Name": 1}}}
+
+        # both names share one email; the later stamp wins the canonical name
+        mapping = dc._merge_author_aliases(
+            email_to_latest={"a@x.com": (400, "New Name")},
+            author_to_email={"old name": "a@x.com", "New Name": "a@x.com"},
+        )
+
+        assert mapping == {"old name": "New Name"}
+        assert set(dc.authors) == {"New Name"}
+        merged = dc.authors["New Name"]
+        assert merged["commits"] == 5
+        assert merged["lines_added"] == 15
+        assert merged["first_commit_stamp"] == 100  # earliest wins
+        assert merged["last_commit_stamp"] == 400  # latest wins
+        assert merged["active_days"] == {"2024-01-01", "2024-02-02"}
+        # period and tag dicts are re-keyed onto the canonical name
+        assert dc.author_of_month["2024-01"] == {"New Name": 2}
+        assert dc.author_of_year[2024] == {"New Name": 5}
+        assert dc.tags["v1"]["authors"] == {"New Name": 3}
+        assert dc.total_authors == 1
+
+    def test_merge_author_aliases_noop_for_distinct_emails(self):
+        dc = GitDataCollector()
+        dc.authors = {"Ann": {"commits": 1}, "Bo": {"commits": 1}}
+
+        mapping = dc._merge_author_aliases(
+            email_to_latest={"a@x.com": (1, "Ann"), "b@x.com": (2, "Bo")},
+            author_to_email={"Ann": "a@x.com", "Bo": "b@x.com"},
+        )
+
+        assert mapping == {}
+        assert set(dc.authors) == {"Ann", "Bo"}
+        assert dc.total_authors == 2
+
+    def test_collect_calls_every_phase(self, git_repo):
+        """collect() is an orchestrator: each phase runs exactly once."""
+        dc = GitDataCollector()
+        called = []
+
+        def spy(name, result=None):
+            def _f(*args, **kwargs):
+                called.append(name)
+                return result
+
+            return _f
+
+        dc._collect_tags = spy("tags")
+        dc._collect_commit_stats = spy("commits", ({}, {}))
+        dc._merge_author_aliases = spy("aliases", {})
+        dc._collect_files_by_stamp = spy("files")
+        dc._collect_extensions = spy("extensions")
+        dc._collect_line_stats = spy("lines")
+        dc._collect_per_author_line_stats = spy("author_lines")
+        dc._collect_file_churn_and_ownership = spy("churn")
+
+        prevdir = os.getcwd()
+        try:
+            os.chdir(git_repo)
+            dc.collect(git_repo)
+        finally:
+            os.chdir(prevdir)
+
+        assert called == [
+            "tags",
+            "commits",
+            "aliases",
+            "files",
+            "extensions",
+            "lines",
+            "author_lines",
+            "churn",
+        ]
 
 
 # ── run() integration ────────────────────────────────────────────────────


### PR DESCRIPTION
Closes #218.

## Summary

`GitDataCollector.collect()` had grown to ~540 lines (larger than when #218 was filed) holding every kind of data collection at once. It is now a 21-line orchestrator that reads as a list of phases, each owning one slice of the data model.

| Method | Lines | Responsibility |
|---|---:|---|
| `collect` | 21 | orchestration only |
| `_collect_tags` | 65 | tag dates, commit counts, authors |
| `_collect_commit_stats` | 66 | per-commit walk; returns identity maps |
| `_record_activity` | 32 | time-of-commit histograms |
| `_record_author_commit` | 45 | per-author and per-period stats |
| `_merge_author_aliases` | 69 | folds shared-email identities → alias map |
| `_collect_files_by_stamp` | 50 | file count per revision |
| `_collect_extensions` | 55 | files/size/lines per extension |
| `_collect_line_stats` | 82 | lines added/removed over time |
| `_collect_per_author_line_stats` | 74 | per-author line attribution |
| `_collect_file_churn_and_ownership` | 26 | churn + code ownership |

The only value threaded between phases is the author-alias mapping that later phases need to attribute work to canonical identities — that data dependency is now explicit in the signatures instead of being an implicit local variable.

## Behaviour is unchanged — verified, not assumed

This is a pure structural refactor. To prove it, every attribute produced by `collect()` + `refine()` was snapshotted before and after the change on two repositories:

1. **this repository** — many authors, tags, merge commits
2. **a synthetic repository** — exercises alias merging (one email, two names), a `[bot]` author, and two tags

Both dumps are **byte-identical** before vs after. Full suite passes (235 tests) and report generation still produces all 7 pages.

## Dead code the split exposed

Separating the scopes surfaced two dead stores that were invisible while everything shared one function scope (ruff could not see them because the variables stayed live across phases):

- an unused `author` binding in the line-stats loop — that loop does not attribute per author; `_collect_per_author_line_stats` does
- an unused file count in the per-author loop — only the line deltas are read there

Both removed; the `int()` cast that guards the `ValueError` path is preserved.

## Tests

Adds unit tests for the phases that are now testable in isolation without a repository — which was the core complaint in #218:

- `_record_activity` — hour/weekday/hour-of-week/month/week histograms and the "busiest" peaks
- `_record_author_commit` — first/last commit span with out-of-order stamps, active days, per-period counts
- `_merge_author_aliases` — shared-email folding across `authors`, period dicts and tag dicts, plus the no-op case for distinct emails
- `collect()` — asserts each phase runs exactly once, in order

---
_Generated by [Claude Code](https://claude.ai/code/session_018tGp6ckSYnGMCpjeSZgTgZ)_

<!-- readthedocs-preview gitstats start -->
----
📚 Documentation preview 📚: https://gitstats--265.org.readthedocs.build/

<!-- readthedocs-preview gitstats end -->