### PR TITLE
feat: add History page — the project's life, one year at a time

### DIFF
--- a/gitstats/gitstats.css
+++ b/gitstats/gitstats.css
@@ -550,6 +550,102 @@ table.noborders td:hover .bar {
 	line-height: 1.6;
 }
 
+/* ===== History ===== */
+.history-summary {
+	padding: var(--space-4);
+	margin: var(--space-4) 0;
+	background-color: var(--surface-color);
+	border: 1px solid var(--border-strong);
+}
+
+.history-summary p:first-child {
+	margin-top: 0;
+}
+
+.history-summary p {
+	color: var(--text-secondary);
+	line-height: 1.6;
+}
+
+.history-year {
+	padding: var(--space-3) var(--space-4);
+	margin-bottom: var(--space-3);
+	border: 1px solid var(--border-color);
+	border-left: 3px solid var(--border-strong);
+}
+
+.history-year-head {
+	display: flex;
+	align-items: baseline;
+	gap: var(--space-3);
+	margin-bottom: var(--space-2);
+}
+
+.history-year-num {
+	font-family: var(--font-mono);
+	font-size: var(--font-size-lg);
+	font-weight: 700;
+	color: var(--text-color);
+}
+
+.history-era {
+	font-family: var(--font-mono);
+	font-size: var(--font-size-xs);
+	font-weight: 600;
+	letter-spacing: 0.08em;
+	padding: 1px var(--space-2);
+	border: 1px solid var(--border-strong);
+	color: var(--text-secondary);
+}
+
+.history-era-birth {
+	color: var(--link-color);
+	border-color: var(--link-color);
+}
+
+.history-era-peak,
+.history-era-surge,
+.history-era-revival {
+	color: var(--success-color);
+	border-color: var(--success-color);
+}
+
+.history-era-quiet,
+.history-era-dormant {
+	color: var(--text-muted);
+	border-color: var(--border-color);
+}
+
+.history-era-desc {
+	font-size: var(--font-size-sm);
+	color: var(--text-muted);
+}
+
+.history-bar-track {
+	height: 6px;
+	margin-bottom: var(--space-2);
+	background-color: var(--surface-color);
+	border: 1px solid var(--border-color);
+}
+
+.history-bar {
+	height: 100%;
+	background-color: var(--bar-color);
+}
+
+.history-facts {
+	margin: var(--space-1) 0;
+	font-family: var(--font-mono);
+	font-size: var(--font-size-sm);
+	color: var(--text-secondary);
+}
+
+.history-people {
+	margin: var(--space-1) 0;
+	font-size: var(--font-size-sm);
+	color: var(--text-secondary);
+}
+
 /* ===== Footer ===== */
 .footer {
 	margin-top: var(--space-6);

--- a/gitstats/report_creator.py
+++ b/gitstats/report_creator.py
@@ -78,6 +78,7 @@ class HTMLReportCreator(ReportCreator):
         self.create_lines_html(data, path)
         self.create_tags_html(data, path)
         self.create_ownership_html(data, path)
+        self.create_history_html(data, path)
 
         # Create AI Insights page if AI is enabled
         if hasattr(data, "ai_summaries") and data.ai_summaries:
@@ -1054,6 +1055,131 @@ class HTMLReportCreator(ReportCreator):
         f.write("</body></html>")
         f.close()
 
+    _ERA_DESCRIPTIONS = {
+        "birth": "first commits",
+        "peak": "busiest year",
+        "surge": "well above the usual pace",
+        "revival": "active again after a lull",
+        "quiet": "well below the usual pace",
+        "dormant": "no commits",
+        "steady": "",
+    }
+
+    def create_history_html(self, data: Any, path: str) -> None:
+        """Create the History page: the project's life, one year at a time.
+
+        A deterministic timeline derived entirely from already-collected data:
+        each year is classified against the repository's own baseline (birth,
+        peak, surge, quiet, dormant, revival), and carries its commit volume,
+        the year's leading author, the contributors who made their first
+        commit that year, and the releases tagged in it.
+        """
+        f = self._open_report_file(path, "history.html")
+        self.print_header(f)
+        self.print_nav(f)
+        f.write("<h1>History</h1>")
+
+        history = compute_project_history(data)
+        years = history["years"]
+
+        if not years:
+            f.write(
+                '<div class="history-summary"><p>No history to tell yet — '
+                "this repository has no commits in the analyzed range.</p></div>"
+            )
+            self.print_footer(f)
+            f.write("</body></html>")
+            f.close()
+            return
+
+        span = history["last_year"] - history["first_year"] + 1
+        f.write(
+            '<div class="history-summary">'
+            "<p>The project's life, one year at a time, told from the commit "
+            "record: how activity rose and fell against the project's own "
+            "baseline, who arrived when, and what was released.</p>"
+            "<dl>"
+            "<dt>Span</dt><dd>%d – %d (%d year%s)</dd>"
+            "<dt>Peak year</dt><dd>%d</dd>"
+            "<dt>Releases</dt><dd>%d</dd>"
+            "</dl></div>"
+            % (
+                history["first_year"],
+                history["last_year"],
+                span,
+                "s" if span != 1 else "",
+                history["peak_year"],
+                history["total_releases"],
+            )
+        )
+
+        max_commits = max(y["commits"] for y in years)
+        for entry in years:
+            era = entry["era"]
+            desc = self._ERA_DESCRIPTIONS.get(era, "")
+            bar_pct = round(100.0 * entry["commits"] / max_commits, 1) if max_commits else 0.0
+
+            f.write('<div class="history-year">')
+            f.write(
+                '<div class="history-year-head">'
+                '<span class="history-year-num">%d</span>'
+                '<span class="history-era history-era-%s">%s</span>'
+                "%s</div>"
+                % (
+                    entry["year"],
+                    era,
+                    era.upper(),
+                    f'<span class="history-era-desc">{desc}</span>' if desc else "",
+                )
+            )
+            f.write(
+                '<div class="history-bar-track"><div class="history-bar" '
+                'style="width:%s%%"></div></div>' % bar_pct
+            )
+
+            if entry["commits"]:
+                facts = "%d commits (%s%%) &middot; +%d / &minus;%d lines &middot; %d author%s" % (
+                    entry["commits"],
+                    entry["commits_pct"],
+                    entry["lines_added"],
+                    entry["lines_removed"],
+                    entry["active_authors"],
+                    "s" if entry["active_authors"] != 1 else "",
+                )
+                f.write(f'<p class="history-facts">{facts}</p>')
+                if entry["top_author"]:
+                    f.write(
+                        '<p class="history-people">Led by <strong>%s</strong> (%d commits)</p>'
+                        % (html.escape(entry["top_author"]), entry["top_author_commits"])
+                    )
+                if entry["newcomers"]:
+                    f.write(
+                        '<p class="history-people">First commits: %s%s</p>'
+                        % (
+                            ", ".join(html.escape(n) for n in entry["newcomers"][:6]),
+                            " (+%d more)" % (len(entry["newcomers"]) - 6)
+                            if len(entry["newcomers"]) > 6
+                            else "",
+                        )
+                    )
+                if entry["releases"]:
+                    f.write(
+                        '<p class="history-people">Released: %s%s</p>'
+                        % (
+                            ", ".join(html.escape(t) for t in entry["releases"][:5]),
+                            " (+%d more)" % (len(entry["releases"]) - 5)
+                            if len(entry["releases"]) > 5
+                            else "",
+                        )
+                    )
+            else:
+                f.write('<p class="history-facts">No commits this year.</p>')
+            f.write("</div>")
+
+        self.print_footer(f)
+        f.write("</body></html>")
+        f.close()
+
     def create_ai_insights_html(self, data: Any, path: str) -> None:
         """
         Create a dedicated AI Insights page with all AI-generated summaries.
@@ -1313,6 +1439,7 @@ class HTMLReportCreator(ReportCreator):
             <li><a href="lines.html">Lines</a></li>
             <li><a href="tags.html">Tags</a></li>
             <li><a href="ownership.html">Code Ownership</a></li>
+            <li><a href="history.html">History</a></li>
             {ai_link}
             </ul>
             <div class="nav-right">
@@ -1428,6 +1555,134 @@ def compute_code_ownership(author_files: dict[str, dict[str, int]]) -> dict[str,
         "authors": authors_stats,
         "total_files": len(files_stats),
         "single_owner_files": sum(1 for fs in files_stats if fs["contributors"] == 1),
+    }
+
+
+def _classify_eras(year_commits: dict[int, int]) -> dict[int, str]:
+    """Assign each year of the project's span one era label.
+
+    Labels are relative to the repository's own baseline (the median of its
+    non-zero years), so a "surge" in a small project and in a huge one mean
+    the same thing: well above what is normal *for that project*. The span is
+    contiguous — years without commits appear as "dormant" instead of being
+    skipped, because silence is part of the story.
+
+    Priority per year: birth > dormant > peak > revival > surge > quiet > steady.
+    """
+    if not year_commits:
+        return {}
+    first, last = min(year_commits), max(year_commits)
+    span = {y: year_commits.get(y, 0) for y in range(first, last + 1)}
+    active = [c for c in span.values() if c > 0]
+    med = sorted(active)[len(active) // 2]
+    peak_year = max(span, key=lambda y: (span[y], y))
+    # With under three active years there is no meaningful baseline to
+    # compare against, so only the structural labels apply.
+    tiny = len(active) < 3
+
+    eras: dict[int, str] = {}
+    prev = ""
+    for y in sorted(span):
+        c = span[y]
+        if y == first:
+            era = "birth"
+        elif c == 0:
+            era = "dormant"
+        elif y == peak_year and not tiny:
+            era = "peak"
+        elif prev in ("dormant", "quiet") and c >= med:
+            era = "revival"
+        elif not tiny and c >= 1.6 * med:
+            era = "surge"
+        elif not tiny and c <= 0.35 * med:
+            era = "quiet"
+        else:
+            era = "steady"
+        eras[y] = era
+        prev = era
+    return eras
+
+
+def compute_project_history(data: Any) -> dict[str, Any]:
+    """Derive a chronological, per-year account of the project from collected data.
+
+    Everything here is computed from data the collector already gathered —
+    no extra git traffic. Bot accounts (names ending in ``[bot]``) are left
+    out of the people-facing fields. Returns a dict with:
+        years: one entry per calendar year of the span (gap years included),
+               each carrying commits, line deltas, author counts, the top
+               author, newcomers (authors whose first commit fell in that
+               year, most active first) and the releases tagged that year;
+        first_year, last_year, peak_year, total_releases.
+    """
+    year_commits: dict[int, int] = dict(getattr(data, "commits_by_year", {}) or {})
+    if not year_commits:
+        return {
+            "years": [],
+            "first_year": None,
+            "last_year": None,
+            "peak_year": None,
+            "total_releases": 0,
+        }
+
+    eras = _classify_eras(year_commits)
+    author_of_year = getattr(data, "author_of_year", {}) or {}
+    lines_added = getattr(data, "lines_added_by_year", {}) or {}
+    lines_removed = getattr(data, "lines_removed_by_year", {}) or {}
+
+    # Authors whose first commit fell in each year (bots excluded).
+    newcomers_by_year: dict[int, list[str]] = {}
+    for name, info in (getattr(data, "authors", {}) or {}).items():
+        stamp = info.get("first_commit_stamp") if isinstance(info, dict) else None
+        if not stamp or name.endswith("[bot]"):
+            continue
+        yy = datetime.datetime.fromtimestamp(stamp).year
+        newcomers_by_year.setdefault(yy, []).append(name)
+
+    # Releases (tags) by the year they were made.
+    releases_by_year: dict[int, list[tuple[str, str]]] = {}
+    total_releases = 0
+    for tag, info in (getattr(data, "tags", {}) or {}).items():
+        date = str(info.get("date", ""))
+        if len(date) >= 4 and date[:4].isdigit():
+            releases_by_year.setdefault(int(date[:4]), []).append((date, tag))
+            total_releases += 1
+
+    total_commits = sum(year_commits.values())
+    years: list[dict[str, Any]] = []
+    for y in sorted(eras):
+        commits = year_commits.get(y, 0)
+        year_authors = author_of_year.get(y, {})
+        humans = {a: c for a, c in year_authors.items() if not a.endswith("[bot]")}
+        ranked = sorted(humans or year_authors, key=lambda a: (year_authors[a], a), reverse=True)
+        top_author = ranked[0] if ranked else ""
+        newcomers = sorted(
+            newcomers_by_year.get(y, []),
+            key=lambda a: (year_authors.get(a, 0), a),
+            reverse=True,
+        )
+        years.append(
+            {
+                "year": y,
+                "era": eras[y],
+                "commits": commits,
+                "commits_pct": round(100.0 * commits / total_commits, 1) if total_commits else 0.0,
+                "lines_added": lines_added.get(y, 0),
+                "lines_removed": lines_removed.get(y, 0),
+                "active_authors": len(year_authors),
+                "top_author": top_author,
+                "top_author_commits": year_authors.get(top_author, 0),
+                "newcomers": newcomers,
+                "releases": [t for _, t in sorted(releases_by_year.get(y, []))],
+            }
+        )
+
+    return {
+        "years": years,
+        "first_year": years[0]["year"],
+        "last_year": years[-1]["year"],
+        "peak_year": max(year_commits, key=lambda y: (year_commits[y], y)),
+        "total_releases": total_releases,
     }
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -270,6 +270,7 @@ def mock_data_collector():
     data.authors = {
         "Alice Smith": {
             "commits": 30,
+            "first_commit_stamp": 1673776800,  # 2023-01-15
             "lines_added": 2000,
             "lines_removed": 500,
             "date_first": "2023-01-15",
@@ -281,6 +282,7 @@ def mock_data_collector():
         },
         "Bob Jones": {
             "commits": 15,
+            "first_commit_stamp": 1675245600,  # 2023-02-01
             "lines_added": 800,
             "lines_removed": 300,
             "date_first": "2023-02-01",
@@ -292,6 +294,7 @@ def mock_data_collector():
         },
         "Charlie Brown": {
             "commits": 5,
+            "first_commit_stamp": 1678442400,  # 2023-03-10
             "lines_added": 200,
             "lines_removed": 200,
             "date_first": "2023-03-10",

--- a/tests/test_report_creator.py
+++ b/tests/test_report_creator.py
@@ -9,7 +9,9 @@ import pytest
 from gitstats.report_creator import (
     HTMLReportCreator,
     ReportCreator,
+    _classify_eras,
     compute_code_ownership,
+    compute_project_history,
     get_keys_sorted_by_value_key,
     get_keys_sorted_by_values,
     html_header,
@@ -646,6 +648,7 @@ def test_create_all_pages(mock_data_collector, temp_dir):
         "lines.html",
         "tags.html",
         "ownership.html",
+        "history.html",
     ]
     for fname in expected_files:
         path = f"{temp_dir}/{fname}"
@@ -760,3 +763,115 @@ def test_open_report_file_confined_to_report_dir(temp_dir):
     assert os.path.exists(f"{temp_dir}/ownership.html")
     with pytest.raises(ValueError):
         creator._open_report_file(temp_dir, "../escape.html")
+
+
+# ── Project history ──────────────────────────────────────────────────────
+
+
+def test_classify_eras_full_arc():
+    """A long life: birth, surge, silence, revival, peak — all detected."""
+    eras = _classify_eras({2019: 55, 2020: 20, 2021: 2, 2023: 30, 2024: 120, 2025: 60, 2026: 25})
+    # median of non-zero years (2,20,25,30,55,60,120) = 30
+    assert eras[2019] == "birth"
+    assert eras[2021] == "quiet"  # 2 <= 0.35 * 30
+    assert eras[2022] == "dormant"  # gap year, no commits at all
+    assert eras[2023] == "revival"  # back at the baseline after silence
+    assert eras[2024] == "peak"  # the maximum year
+    assert eras[2025] == "surge"  # 60 >= 1.6 * 30
+    assert eras[2026] == "steady"
+
+
+def test_classify_eras_tiny_history():
+    """With under three active years only structural labels apply."""
+    assert _classify_eras({2024: 10}) == {2024: "birth"}
+    assert _classify_eras({2024: 10, 2025: 100}) == {2024: "birth", 2025: "steady"}
+    assert _classify_eras({}) == {}
+
+
+def test_compute_project_history_fields(mock_data_collector):
+    history = compute_project_history(mock_data_collector)
+
+    assert history["first_year"] == 2023
+    assert history["last_year"] == 2023
+    assert history["peak_year"] == 2023
+    assert history["total_releases"] == 2  # v1.0.0 + v1.1.0
+
+    (y,) = history["years"]
+    assert y["year"] == 2023
+    assert y["era"] == "birth"
+    assert y["commits"] == 50
+    assert y["commits_pct"] == 100.0
+    assert y["top_author"] == "Alice Smith"
+    assert y["top_author_commits"] == 30
+    # all three authors first appeared in 2023, ranked by that year's commits
+    assert y["newcomers"] == ["Alice Smith", "Bob Jones", "Charlie Brown"]
+    assert y["releases"] == ["v1.0.0", "v1.1.0"]
+
+
+def test_compute_project_history_excludes_bots():
+    class Data:
+        commits_by_year = {2024: 10}
+        author_of_year = {2024: {"dependabot[bot]": 8, "Ann": 2}}
+        lines_added_by_year = {}
+        lines_removed_by_year = {}
+        authors = {
+            "Ann": {"first_commit_stamp": 1704067200},  # 2024-01-01
+            "dependabot[bot]": {"first_commit_stamp": 1704067200},
+        }
+        tags = {}
+
+    (y,) = compute_project_history(Data())["years"]
+    assert y["top_author"] == "Ann"  # the bot outnumbers her but is skipped
+    assert y["newcomers"] == ["Ann"]
+    assert y["active_authors"] == 2  # raw count still includes everyone
+
+
+def test_compute_project_history_empty():
+    class Data:
+        commits_by_year = {}
+
+    history = compute_project_history(Data())
+    assert history["years"] == []
+    assert history["first_year"] is None
+
+
+def test_history_page_renders(mock_data_collector, temp_dir):
+    creator = HTMLReportCreator()
+    creator.create(mock_data_collector, temp_dir)
+
+    with open(f"{temp_dir}/history.html", encoding="utf-8") as f:
+        content = f.read()
+
+    assert "History" in content
+    assert "BIRTH" in content
+    assert "Alice Smith" in content
+    assert "v1.0.0" in content
+    assert "</html>" in content
+
+
+def test_history_page_empty_state(mock_data_collector, temp_dir):
+    mock_data_collector.commits_by_year = {}
+    creator = HTMLReportCreator()
+    creator.data = mock_data_collector
+    creator.title = "t"
+    creator.create_history_html(mock_data_collector, temp_dir)
+
+    with open(f"{temp_dir}/history.html", encoding="utf-8") as f:
+        content = f.read()
+
+    assert "No history to tell yet" in content
+    assert "</html>" in content
+
+
+def test_history_page_escapes_names(mock_data_collector, temp_dir):
+    mock_data_collector.author_of_year = {2023: {"Al<ice>": 50}}
+    mock_data_collector.authors = {"Al<ice>": {"first_commit_stamp": 1673776800}}
+    creator = HTMLReportCreator()
+    creator.data = mock_data_collector
+    creator.title = "t"
+    creator.create_history_html(mock_data_collector, temp_dir)
+
+    with open(f"{temp_dir}/history.html", encoding="utf-8") as f:
+        content = f.read()
+
+    assert "Al&lt;ice&gt;" in content


### PR DESCRIPTION
## Summary

Phase 1 of the project-chronicle idea: a **deterministic History page** that turns already-collected data into the project's arc — no AI, no network, **zero additional git traffic**.

Run on the original `hoxu/gitstats` (2007–2015), the page tells its story at a glance: 2007 **BIRTH** (one author, 36% of all commits), 2009 **SURGE**, steady years where the contributor community forms name by name, and 2015 **QUIET** — the dormancy this fork later revived.

## What the page shows

- **Era classification per year**, measured against the repository's *own* baseline (median of its non-zero years): `birth`, `peak`, `surge` (≥1.6× median), `quiet` (≤0.35× median), `revival` (active again after a lull) — and `dormant` for gap years with zero commits, which every existing page silently skips even though silence is part of the story.
- Per year: commit volume with a proportional bar, +/− lines, author count, the year's **leading author**, the **contributors whose first commit fell in that year** (collected in `authors[*].first_commit_stamp` but never shown anywhere until now), and the **releases tagged** that year.
- Bot accounts (`[bot]`) are excluded from people-facing fields.

## Design decisions

- **Deterministic first.** This page is the grounded "fact layer"; a later phase can layer optional AI narration on top of these exact facts (reusing the existing `ai_*` infrastructure), which keeps any narrative honest by construction.
- **Relative, not absolute thresholds.** A "surge" means *above what is normal for this project*, so the labels are meaningful on a 300-commit repo and a 300k-commit repo alike. Histories with fewer than three active years get only structural labels (no baseline to compare against).
- **Bounded by construction.** Entry count equals the year span; newcomers/releases are capped per entry. No inline JSON, no chart library — the bars are plain CSS, matching the report's ledger aesthetic.

## Implementation

- `_classify_eras` + `compute_project_history` are pure module-level functions (same pattern as `compute_code_ownership`), unit-tested for: the full arc (birth/surge/quiet/dormant/revival/peak), tiny histories, bot exclusion, empty repositories, tie-breaking, and HTML escaping.
- `create_history_html` renders through the directory-confined `_open_report_file`; every author/tag name is escaped.
- Nav gains a **History** link. 243 tests pass.

## Note

`feature/add-hotspots-analysis` (#246) also touches the nav and `create()`; whichever merges second will need a trivial rebase of those two lines.