### PR TITLE
feat: AI chronicle narration on the History page

### DIFF
--- a/gitstats/ai_summarizer.py
+++ b/gitstats/ai_summarizer.py
@@ -386,6 +386,72 @@ Top 5 Contributors by Lines:
 """
         return context
 
+    def prepare_chronicle_data(self, data: dict[str, Any]) -> str:
+        """Prepare the year-by-year fact pack that grounds the chronicle.
+
+        Reuses the same deterministic history computation that renders the
+        History page, so the narration and the visible facts can never
+        disagree, and adds the sampled commit subjects for period flavor.
+        """
+        from types import SimpleNamespace
+
+        from gitstats.report_creator import compute_project_history
+
+        view = SimpleNamespace(
+            **{
+                key: self._get_field_value(data, key, {})
+                for key in (
+                    "commits_by_year",
+                    "author_of_year",
+                    "lines_added_by_year",
+                    "lines_removed_by_year",
+                    "authors",
+                    "tags",
+                )
+            }
+        )
+        history = compute_project_history(view)
+        if not history["years"]:
+            return "Project History:\n(no commits in the analyzed range)"
+
+        subjects_by_year = self._get_field_value(data, "commit_subjects_by_year", {}) or {}
+        project_name = self._get_field_value(data, "project_name", "this project")
+
+        blocks = []
+        for y in history["years"]:
+            lines = [
+                "Year %d [%s]: %d commits (%s%% of all), +%d/-%d lines, %d author%s."
+                % (
+                    y["year"],
+                    y["era"],
+                    y["commits"],
+                    y["commits_pct"],
+                    y["lines_added"],
+                    y["lines_removed"],
+                    y["active_authors"],
+                    "s" if y["active_authors"] != 1 else "",
+                )
+            ]
+            if y["top_author"]:
+                lines.append(
+                    "  Leading author: %s (%d commits)" % (y["top_author"], y["top_author_commits"])
+                )
+            if y["newcomers"]:
+                lines.append("  First-time contributors: " + ", ".join(y["newcomers"][:8]))
+            if y["releases"]:
+                lines.append("  Releases: " + ", ".join(y["releases"][:6]))
+            subjects = subjects_by_year.get(y["year"], [])
+            if subjects:
+                lines.append("  Sample commit subjects: " + "; ".join('"%s"' % s for s in subjects))
+            blocks.append("\n".join(lines))
+
+        return "Project History of %s (%d - %d):\n\n%s" % (
+            project_name,
+            history["first_year"],
+            history["last_year"],
+            "\n\n".join(blocks),
+        )
+
     def generate_summary(
         self, page_type: str, data: dict[str, Any], force_refresh: bool = False
     ) -> dict[str, Any]:
@@ -419,6 +485,12 @@ Top 5 Contributors by Lines:
             elif page_type == "lines":
                 data_context = self.prepare_lines_data(data)
                 prompt_focus = "summarize the codebase growth trajectory and what it indicates about the project."
+            elif page_type == "chronicle":
+                data_context = self.prepare_chronicle_data(data)
+                prompt_focus = (
+                    "write the project's chronicle: a short, engaging story of how it "
+                    "came to be, told strictly from the facts below."
+                )
             else:
                 result["error"] = f"Unknown page type: {page_type}"
                 return result
@@ -436,11 +508,21 @@ Top 5 Contributors by Lines:
 
             # Construct prompt
             language_instruction = self._get_language_instruction()
-            prompt = f"""You are analyzing git repository statistics. Based on the following data, {prompt_focus}
-
-{data_context}
-
-Requirements:
+            if page_type == "chronicle":
+                requirements = f"""Requirements:
+- Output PLAIN TEXT only: no HTML, no markdown, no bullet lists
+- Follow this exact structure, one block per year, in this order:
+[PROLOGUE]
+One short paragraph (2-3 sentences) framing the whole story.
+[YEAR <year>] <a short chapter title, a few words>
+One paragraph (2-4 sentences) telling that year's part of the story.
+- Include a [YEAR ...] block for EVERY year listed in the data, including dormant ones
+- Only narrate facts present in the data; never invent events, names, numbers or motivations
+- Use the era labels, contributor arrivals, releases and commit subjects as your material
+- Write vividly but honestly - a quiet year is part of the story, not a failure
+- {language_instruction}"""
+            else:
+                requirements = f"""Requirements:
 - Keep analysis concise: 2-3 short paragraphs maximum
 - Start with 2-3 key findings as bullet points using <ul><li><strong>Key finding</strong>: explanation</li></ul>
 - Use specific numbers and percentages to support your points
@@ -448,7 +530,13 @@ Requirements:
 - Focus on actionable insights rather than generic recommendations
 - Use clear, conversational language rather than academic tone
 - Format your response in HTML (use <p>, <ul>, <li>, <strong>, <em> tags)
-- {language_instruction}
+- {language_instruction}"""
+
+            prompt = f"""You are analyzing git repository statistics. Based on the following data, {prompt_focus}
+
+{data_context}
+
+{requirements}
 
 Generate your analysis:"""
 
@@ -484,7 +572,7 @@ Generate your analysis:"""
             Dictionary mapping page types to summary results
         """
         summaries = {}
-        page_types = ["index", "activity", "lines"]
+        page_types = ["index", "activity", "lines", "chronicle"]
 
         for page_type in page_types:
             summaries[page_type] = self.generate_summary(page_type, data, force_refresh)

--- a/gitstats/gitstats.css
+++ b/gitstats/gitstats.css
@@ -633,6 +633,40 @@ table.noborders td:hover .bar {
 	background-color: var(--bar-color);
 }
 
+.history-prologue {
+	padding: var(--space-4);
+	margin: var(--space-4) 0;
+	border: 1px solid var(--border-color);
+	border-left: 3px solid var(--link-color);
+}
+
+.history-prologue p {
+	margin: 0 0 var(--space-2);
+	line-height: 1.7;
+	color: var(--text-color);
+	max-width: 72ch;
+}
+
+.history-ai-note {
+	font-family: var(--font-mono);
+	font-size: var(--font-size-xs) !important;
+	color: var(--text-muted) !important;
+	letter-spacing: 0.04em;
+}
+
+.history-chapter-title {
+	font-size: var(--font-size-md);
+	font-style: italic;
+	color: var(--text-color);
+}
+
+.history-story {
+	margin: var(--space-2) 0;
+	line-height: 1.7;
+	color: var(--text-color);
+	max-width: 72ch;
+}
+
 .history-facts {
 	margin: var(--space-1) 0;
 	font-family: var(--font-mono);

--- a/gitstats/main.py
+++ b/gitstats/main.py
@@ -74,6 +74,14 @@ def parallel_map_with_fallback(func, items):
         return [func(item) for item in items]
 
 
+def _sample_evenly(items: list[str], k: int) -> list[str]:
+    """Pick up to ``k`` items spread evenly across the list, order preserved."""
+    if len(items) <= k:
+        return list(items)
+    step = len(items) / k
+    return [items[int(i * step)] for i in range(k)]
+
+
 def _merge_period_aliases(
     period_authors: dict[str, int], name_to_canonical: dict[str, str]
 ) -> None:
@@ -156,6 +164,10 @@ class DataCollector:
         # code ownership: author -> file path -> number of commits touching it
         self.author_files: dict[str, dict[str, int]] = {}
 
+        # evenly sampled commit subjects per year (collected only when AI
+        # features are enabled; they ground the AI chronicle narration)
+        self.commit_subjects_by_year: dict[int, list[str]] = {}
+
         # new contributors per month
         self.new_contributors_by_month: dict[str, int] = {}  # YYYY-MM -> count
 
@@ -223,6 +235,8 @@ class GitDataCollector(DataCollector):
         self._collect_line_stats()
         self._collect_per_author_line_stats(name_to_canonical)
         self._collect_file_churn_and_ownership(name_to_canonical)
+        if conf["ai_enabled"]:
+            self._collect_commit_subjects()
 
     # ── collection phases ────────────────────────────────────────────────
 
@@ -796,6 +810,36 @@ class GitDataCollector(DataCollector):
             if current_author:
                 author_map = self.author_files.setdefault(current_author, {})
                 author_map[line] = author_map.get(line, 0) + 1
+
+    def _collect_commit_subjects(self) -> None:
+        """Sample commit subjects per year to ground the AI chronicle.
+
+        One subjects-only pass in chronological order; each year keeps an
+        evenly spaced sample so the whole span stays represented no matter
+        how large the repository is. Only runs when AI features are enabled.
+        """
+        output = get_pipe_output(
+            ['git log --reverse --format="%at %s" {}'.format(get_log_range("HEAD", False))]
+        )
+        by_year: dict[int, list[str]] = {}
+        for line in output.split("\n"):
+            line = line.strip()
+            if not line:
+                continue
+            pos = line.find(" ")
+            if pos == -1:
+                continue
+            try:
+                year = datetime.datetime.fromtimestamp(int(line[:pos])).year
+            except ValueError:
+                continue
+            subject = line[pos + 1 :].strip()
+            if subject:
+                by_year.setdefault(year, []).append(subject[:100])
+
+        self.commit_subjects_by_year = {
+            year: _sample_evenly(subjects, 10) for year, subjects in by_year.items()
+        }
 
     def refine(self) -> None:
         # authors

--- a/gitstats/report_creator.py
+++ b/gitstats/report_creator.py
@@ -7,6 +7,7 @@ import html
 import json
 import math
 import os
+import re
 import shutil
 import time
 from typing import Any
@@ -1113,25 +1114,54 @@ class HTMLReportCreator(ReportCreator):
             )
         )
 
+        # Optional AI narration: parsed into per-year chapters and laid over
+        # the deterministic facts, which stay visible either way so the story
+        # can always be checked against the record it was written from.
+        ai_summaries = getattr(data, "ai_summaries", {}) or {}
+        chronicle_text = (ai_summaries.get("chronicle") or {}).get("summary") or ""
+        chronicle = parse_chronicle(chronicle_text) if chronicle_text else None
+
+        if chronicle and chronicle["prologue"]:
+            f.write(
+                '<div class="history-prologue"><p>%s</p>'
+                '<p class="history-ai-note">AI narration, generated from the facts below.</p></div>'
+                % html.escape(chronicle["prologue"])
+            )
+        if chronicle_text and (not chronicle or not chronicle["chapters"]):
+            # The model ignored the format: show its text whole rather than lose it.
+            f.write(
+                '<div class="history-prologue"><p>%s</p>'
+                '<p class="history-ai-note">AI narration, generated from the facts below.</p></div>'
+                % html.escape(chronicle_text)
+            )
+
         max_commits = max(y["commits"] for y in years)
         for entry in years:
             era = entry["era"]
             desc = self._ERA_DESCRIPTIONS.get(era, "")
             bar_pct = round(100.0 * entry["commits"] / max_commits, 1) if max_commits else 0.0
+            chapter = chronicle["chapters"].get(entry["year"]) if chronicle else None
 
             f.write('<div class="history-year">')
             f.write(
                 '<div class="history-year-head">'
                 '<span class="history-year-num">%d</span>'
                 '<span class="history-era history-era-%s">%s</span>'
-                "%s</div>"
+                "%s%s</div>"
                 % (
                     entry["year"],
                     era,
                     era.upper(),
-                    f'<span class="history-era-desc">{desc}</span>' if desc else "",
+                    '<span class="history-chapter-title">%s</span>' % html.escape(chapter["title"])
+                    if chapter and chapter["title"]
+                    else "",
+                    f'<span class="history-era-desc">{desc}</span>'
+                    if desc and not (chapter and chapter["title"])
+                    else "",
                 )
             )
+            if chapter and chapter["story"]:
+                f.write('<p class="history-story">%s</p>' % html.escape(chapter["story"]))
             f.write(
                 '<div class="history-bar-track"><div class="history-bar" '
                 'style="width:%s%%"></div></div>' % bar_pct
@@ -1684,6 +1714,40 @@ def compute_project_history(data: Any) -> dict[str, Any]:
         "peak_year": max(year_commits, key=lambda y: (year_commits[y], y)),
         "total_releases": total_releases,
     }
+
+
+def parse_chronicle(text: str) -> dict[str, Any]:
+    """Split AI chronicle text into a prologue and per-year chapters.
+
+    Expects ``[PROLOGUE]`` and ``[YEAR <n>] <title>`` marker lines; everything
+    between markers belongs to the preceding one. Tolerant by design: years
+    the model skipped simply have no chapter, and text with no markers at all
+    yields no chapters so the caller can fall back to showing it whole.
+    """
+    prologue = ""
+    chapters: dict[int, dict[str, str]] = {}
+    current: dict[str, str] | None = None
+    in_prologue = False
+    prologue_lines: list[str] = []
+    marker = re.compile(r"^\[YEAR\s+(\d{4})\]\s*(.*)$")
+
+    for raw_line in text.splitlines():
+        line = raw_line.strip()
+        m = marker.match(line)
+        if m:
+            in_prologue = False
+            current = {"title": m.group(2).strip(), "story": ""}
+            chapters[int(m.group(1))] = current
+        elif line == "[PROLOGUE]":
+            in_prologue = True
+            current = None
+        elif in_prologue:
+            prologue_lines.append(line)
+        elif current is not None and line:
+            current["story"] = (current["story"] + " " + line).strip()
+
+    prologue = " ".join(line for line in prologue_lines if line).strip()
+    return {"prologue": prologue, "chapters": chapters}
 
 
 def html_header(level: int, text: str) -> str:

--- a/tests/test_ai_summarizer.py
+++ b/tests/test_ai_summarizer.py
@@ -629,11 +629,11 @@ def test_generate_all_summaries_covers_index_activity_lines():
     }
     summaries = summarizer.generate_all_summaries(data)
 
-    assert set(summaries.keys()) == {"index", "activity", "lines"}
-    for page_type in ("index", "activity", "lines"):
+    assert set(summaries.keys()) == {"index", "activity", "lines", "chronicle"}
+    for page_type in ("index", "activity", "lines", "chronicle"):
         assert summaries[page_type]["error"] is None
         assert summaries[page_type]["summary"] == "<p>Looks good.</p>"
-    assert mock_provider.generate_summary.call_count == 3
+    assert mock_provider.generate_summary.call_count == 4
 
 
 def test_generate_all_summaries_without_provider_all_error():
@@ -641,7 +641,7 @@ def test_generate_all_summaries_without_provider_all_error():
     data = {"total_commits": 10, "authors": {}}
     summaries = summarizer.generate_all_summaries(data)
 
-    assert set(summaries.keys()) == {"index", "activity", "lines"}
+    assert set(summaries.keys()) == {"index", "activity", "lines", "chronicle"}
     for page_type in summaries:
         assert summaries[page_type]["error"] == "AI provider not initialized"
 
@@ -653,10 +653,82 @@ def test_generate_all_summaries_force_refresh_propagated(tmp_path):
 
     data = {"total_commits": 10, "authors": {}, "commits_by_year": {}, "total_lines": 0}
     summarizer.generate_all_summaries(data)
-    assert mock_provider.generate_summary.call_count == 3
+    assert mock_provider.generate_summary.call_count == 4
 
     mock_provider.generate_summary.return_value = "<p>v2</p>"
     summaries = summarizer.generate_all_summaries(data, force_refresh=True)
-    assert mock_provider.generate_summary.call_count == 6
+    assert mock_provider.generate_summary.call_count == 8
     for page_type in summaries:
         assert summaries[page_type]["summary"] == "<p>v2</p>"
+
+
+# ── chronicle ─────────────────────────────────────────────────────────────
+
+
+CHRONICLE_DATA = {
+    "project_name": "demo",
+    "commits_by_year": {2023: 40, 2024: 80},
+    "author_of_year": {2023: {"Ann": 40}, 2024: {"Ann": 50, "Bo": 30}},
+    "lines_added_by_year": {2023: 100, 2024: 300},
+    "lines_removed_by_year": {2023: 10, 2024: 30},
+    "authors": {
+        "Ann": {"first_commit_stamp": 1673776800},  # 2023
+        "Bo": {"first_commit_stamp": 1717200000},  # 2024
+    },
+    "tags": {"v1.0": {"date": "2024-06-01"}},
+    "commit_subjects_by_year": {2023: ["Initial commit"], 2024: ["Add feature X"]},
+}
+
+
+def test_prepare_chronicle_data_fact_pack():
+    summarizer = make_summarizer()
+    context = summarizer.prepare_chronicle_data(CHRONICLE_DATA)
+
+    assert "Project History of demo (2023 - 2024)" in context
+    assert "Year 2023 [birth]: 40 commits" in context
+    assert "Leading author: Ann (40 commits)" in context
+    assert "First-time contributors: Bo" in context
+    assert "Releases: v1.0" in context
+    assert '"Add feature X"' in context
+
+
+def test_prepare_chronicle_data_empty():
+    summarizer = make_summarizer()
+    context = summarizer.prepare_chronicle_data({"commits_by_year": {}})
+    assert "no commits" in context
+
+
+def test_generate_summary_chronicle_prompt_and_result():
+    summarizer = make_summarizer()
+    provider = Mock()
+    provider.generate_summary.return_value = (
+        "[PROLOGUE]\nA story.\n[YEAR 2023] Beginnings\nAnn started alone."
+    )
+    summarizer.provider = provider
+    summarizer.cache_enabled = False
+
+    result = summarizer.generate_summary("chronicle", CHRONICLE_DATA)
+
+    assert result["error"] is None
+    assert "[YEAR 2023]" in result["summary"]
+    prompt = provider.generate_summary.call_args[0][1]
+    # chronicle-specific format contract, grounded on the fact pack
+    assert "[PROLOGUE]" in prompt
+    assert "[YEAR <year>]" in prompt
+    assert "PLAIN TEXT" in prompt
+    assert "never invent" in prompt
+    assert "Year 2023 [birth]" in prompt
+    # the analytics-page requirements must not leak into the chronicle prompt
+    assert "<ul><li>" not in prompt
+
+
+def test_generate_all_summaries_includes_chronicle():
+    summarizer = make_summarizer()
+    provider = Mock()
+    provider.generate_summary.return_value = "text"
+    summarizer.provider = provider
+    summarizer.cache_enabled = False
+
+    summaries = summarizer.generate_all_summaries(CHRONICLE_DATA)
+
+    assert set(summaries) == {"index", "activity", "lines", "chronicle"}

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -548,6 +548,52 @@ class TestCollectPhases:
         ]
 
 
+# ── commit subject sampling (grounds the AI chronicle) ──────────────────
+
+
+def test_sample_evenly():
+    from gitstats.main import _sample_evenly
+
+    assert _sample_evenly([], 10) == []
+    assert _sample_evenly(["a", "b"], 10) == ["a", "b"]
+    sampled = _sample_evenly([str(i) for i in range(100)], 10)
+    assert len(sampled) == 10
+    assert sampled[0] == "0"
+    # evenly spread and order preserved
+    assert sampled == sorted(sampled, key=int)
+    assert int(sampled[-1]) >= 90
+
+
+class TestCommitSubjects:
+    def test_collected_when_ai_enabled(self, git_repo):
+        import gitstats.main as main_mod
+
+        dc = GitDataCollector()
+        prevdir = os.getcwd()
+        try:
+            os.chdir(git_repo)
+            with patch.dict(main_mod.conf, {"ai_enabled": True}):
+                dc.collect(git_repo)
+        finally:
+            os.chdir(prevdir)
+
+        subjects = dc.commit_subjects_by_year
+        assert set(subjects) == {2023}
+        assert "Initial commit" in subjects[2023]
+        assert len(subjects[2023]) <= 10
+
+    def test_skipped_when_ai_disabled(self, git_repo):
+        dc = GitDataCollector()
+        prevdir = os.getcwd()
+        try:
+            os.chdir(git_repo)
+            dc.collect(git_repo)
+        finally:
+            os.chdir(prevdir)
+
+        assert dc.commit_subjects_by_year == {}
+
+
 # ── run() integration ────────────────────────────────────────────────────
 
 

--- a/tests/test_report_creator.py
+++ b/tests/test_report_creator.py
@@ -16,6 +16,7 @@ from gitstats.report_creator import (
     get_keys_sorted_by_values,
     html_header,
     html_linkify,
+    parse_chronicle,
 )
 
 # ── html_linkify ─────────────────────────────────────────────────────────
@@ -875,3 +876,81 @@ def test_history_page_escapes_names(mock_data_collector, temp_dir):
         content = f.read()
 
     assert "Al&lt;ice&gt;" in content
+
+
+# ── AI chronicle parsing and rendering ───────────────────────────────────
+
+
+def test_parse_chronicle_full():
+    text = """[PROLOGUE]
+A small tool grew into a project.
+Told entirely from its commits.
+[YEAR 2007] The first year
+One author laid the groundwork.
+It compiled on the second try.
+[YEAR 2008] Growing pains
+New contributors arrived."""
+    parsed = parse_chronicle(text)
+
+    assert parsed["prologue"] == "A small tool grew into a project. Told entirely from its commits."
+    assert parsed["chapters"][2007]["title"] == "The first year"
+    assert (
+        parsed["chapters"][2007]["story"]
+        == "One author laid the groundwork. It compiled on the second try."
+    )
+    assert parsed["chapters"][2008]["title"] == "Growing pains"
+
+
+def test_parse_chronicle_without_prologue_or_title():
+    parsed = parse_chronicle("[YEAR 2020]\nJust a story line.")
+    assert parsed["prologue"] == ""
+    assert parsed["chapters"][2020] == {"title": "", "story": "Just a story line."}
+
+
+def test_parse_chronicle_unstructured_text():
+    parsed = parse_chronicle("The model ignored the format entirely.")
+    assert parsed["chapters"] == {}
+    assert parsed["prologue"] == ""
+
+
+def test_history_page_renders_chronicle(mock_data_collector, temp_dir):
+    mock_data_collector.ai_summaries = {
+        "chronicle": {
+            "summary": (
+                "[PROLOGUE]\nHow test-project came to be.\n"
+                "[YEAR 2023] The <first> year\nAlice & Bob built it."
+            ),
+            "error": None,
+        }
+    }
+    creator = HTMLReportCreator()
+    creator.data = mock_data_collector
+    creator.title = "t"
+    creator.create_history_html(mock_data_collector, temp_dir)
+
+    with open(f"{temp_dir}/history.html", encoding="utf-8") as f:
+        content = f.read()
+
+    assert "How test-project came to be." in content
+    assert "AI narration, generated from the facts below." in content
+    # chapter title and story are HTML-escaped and attached to the year block
+    assert "The &lt;first&gt; year" in content
+    assert "Alice &amp; Bob built it." in content
+    # the deterministic facts remain visible alongside the story
+    assert "50 commits (100.0%)" in content
+
+
+def test_history_page_chronicle_fallback_when_unparseable(mock_data_collector, temp_dir):
+    mock_data_collector.ai_summaries = {
+        "chronicle": {"summary": "A free-form narrative without markers.", "error": None}
+    }
+    creator = HTMLReportCreator()
+    creator.data = mock_data_collector
+    creator.title = "t"
+    creator.create_history_html(mock_data_collector, temp_dir)
+
+    with open(f"{temp_dir}/history.html", encoding="utf-8") as f:
+        content = f.read()
+
+    # shown whole rather than dropped
+    assert "A free-form narrative without markers." in content


### PR DESCRIPTION
## Summary

Phase 2 of the chronicle: when AI is enabled, the History page's deterministic timeline gains a **narrated layer** — a prologue plus one short chapter per year (title + 2–4 sentence story), in the language configured by `ai_language`. With AI off, the page is exactly the Phase-1 timeline; nothing changes for non-AI users.

## How it stays honest (the core design)

The whole feature is built so the narration **cannot drift from the record**:

1. **Same facts, one source.** The fact pack sent to the model is produced by the *same* `compute_project_history()` call that renders the visible timeline — the story and the numbers underneath it can never disagree. The pack adds an evenly-spaced sample of commit subjects per year for period flavor (one subjects-only `git log` pass, **gated on `ai_enabled`**, so non-AI runs cost nothing extra).
2. **A strict contract in the prompt.** Plain text only, `[PROLOGUE]` / `[YEAR n] title` blocks, a block for *every* year including dormant ones, and an explicit prohibition on inventing events, names, numbers or motivations.
3. **Facts stay on screen.** Each chapter renders *above* its year's deterministic fact lines, so every sentence can be checked against the data it was written from. A visible "AI narration, generated from the facts below" note labels the layer.
4. **Lenient parsing, no silent loss.** `parse_chronicle` tolerates missing chapters and stray formatting; if the model ignores the format entirely, its text is shown whole instead of dropped. All narrated text is HTML-escaped.

## Integration

Rides the existing AI pipeline end to end: a new `"chronicle"` page type in `AISummarizer` — so the provider abstraction (OpenAI/Claude/Gemini/Ollama), `ai_language`, and response caching all apply unchanged — added to `generate_all_summaries`. The three existing page prompts are byte-identical to before.

## Verification

- **255 tests pass.** New coverage: `_sample_evenly`, subject collection (and its `ai_enabled` gate), the fact pack, the chronicle prompt contract (format markers present, analytics-HTML requirements absent), parsing (well-formed / partial / unstructured), and rendering (chapters, escaping, fallback, facts preserved).
- **End-to-end demo** on the original `hoxu/gitstats` (2007–2015): the full pipeline (subject sampling → fact pack → prompt → parse → render) ran with a stubbed provider, since no API key exists in the development sandbox; the demo narrative was written from the real fact pack. With a configured key, the runtime call is the only step that differs.

## Cost notes

One additional LLM call per report run (cached via the existing `.ai_cache`, keyed on the fact pack, so unchanged history costs nothing to regenerate). Input is bounded: ~10 fact lines per year regardless of repository size.