### PR TITLE
feat: multi-repository analysis with an aggregate portfolio page

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -94,6 +94,20 @@ Usage
 
 If ``<outputpath>`` is omitted, reports are written to ``gitstats-report/`` by default.
 
+Analyze several repositories at once to get a portfolio overview — useful for
+seeing how all of a team's projects are doing in one place:
+
+.. code-block:: bash
+
+   gitstats repo1 repo2 repo3 <outputpath>
+
+Each repository gets its full report in ``<outputpath>/<repo>/`` along with a
+machine-readable ``summary.json``, and an aggregate page at
+``<outputpath>/index.html`` shows a sortable table of every repository —
+commits, authors, recent activity, lines of code and a health label — linking
+into the individual reports. Repositories that fail to analyze are listed on
+the page without stopping the run.
+
 Use ``--verbose`` to show debug-level command logs, or ``--quiet`` to show only warnings and errors:
 
 .. code-block:: bash

--- a/gitstats/aggregate.py
+++ b/gitstats/aggregate.py
@@ -1,0 +1,370 @@
+"""Multi-repository aggregation: per-repo summaries and the portfolio page.
+
+When gitstats is run with several repositories, each repository gets its own
+full report in a subdirectory and this module assembles the portfolio view:
+a machine-readable ``summary.json`` per repository plus one aggregate
+``index.html`` at the output root with a sortable overview table.
+
+The computation functions are pure — they read collector attributes only and
+issue no git commands — mirroring ``compute_project_history`` and
+``compute_code_ownership`` in ``report_creator``.
+"""
+
+import datetime
+import html
+import json
+import logging
+import os
+import re
+import shutil
+from typing import Any
+
+from gitstats import load_config
+from gitstats.report_creator import _classify_eras
+from gitstats.utils import get_version
+
+logger = logging.getLogger("gitstats")
+
+conf = load_config()
+
+_SECONDS_PER_DAY = 86400
+_ACTIVE_WINDOW_DAYS = 365
+
+
+def _slugify_repo(path: str) -> str:
+    """Turn a repository path into a safe directory/display name.
+
+    Takes the basename (after dropping trailing separators and a trailing
+    ``.git``) and keeps only word characters, dots and dashes so the slug can
+    never escape the output directory.
+    """
+    name = os.path.basename(os.path.abspath(path).rstrip("/\\"))
+    if name.endswith(".git"):
+        name = name[: -len(".git")]
+    name = re.sub(r"[^A-Za-z0-9._-]", "-", name).strip(".")
+    if not name or set(name) <= {"-", "_"}:
+        raise ValueError(f"Cannot derive a repository name from path: {path!r}")
+    return name
+
+
+def _is_bot(name: str) -> bool:
+    return name.endswith("[bot]")
+
+
+def compute_repo_summary(data: Any, report_path: str) -> dict[str, Any]:
+    """Reduce one repository's collected data to a small summary dict.
+
+    Pure function over collector attributes — no git calls. Bot accounts
+    (names ending in ``[bot]``) are excluded from the people-facing fields,
+    the same convention as ``compute_project_history``.
+    """
+    now = datetime.datetime.now()
+    cutoff = now.timestamp() - _ACTIVE_WINDOW_DAYS * _SECONDS_PER_DAY
+
+    authors = {
+        name: info
+        for name, info in (getattr(data, "authors", {}) or {}).items()
+        if isinstance(info, dict) and not _is_bot(name)
+    }
+    author_commits = {name: int(info.get("commits", 0)) for name, info in authors.items()}
+    active_12mo = sum(
+        1 for info in authors.values() if int(info.get("last_commit_stamp", 0)) >= cutoff
+    )
+    top_authors = [
+        {"name": name, "commits": commits}
+        for name, commits in sorted(author_commits.items(), key=lambda kv: (-kv[1], kv[0]))[:5]
+    ]
+
+    commits_by_year = {
+        int(year): int(commits)
+        for year, commits in (getattr(data, "commits_by_year", {}) or {}).items()
+    }
+    era = ""
+    if commits_by_year:
+        last_year = max(commits_by_year)
+        era = _classify_eras(commits_by_year).get(last_year, "")
+
+    first_stamp = int(getattr(data, "first_commit_stamp", 0) or 0)
+    last_stamp = int(getattr(data, "last_commit_stamp", 0) or 0)
+    age_days = (last_stamp - first_stamp) // _SECONDS_PER_DAY + 1 if last_stamp else 0
+
+    def _iso(stamp: int) -> str:
+        return datetime.datetime.fromtimestamp(stamp).isoformat(sep=" ") if stamp else ""
+
+    recent_months = set()
+    year, month = now.year, now.month
+    for _ in range(12):
+        recent_months.add(f"{year}-{month:02d}")
+        month -= 1
+        if month == 0:
+            year, month = year - 1, 12
+    commits_by_month = getattr(data, "commits_by_month", {}) or {}
+    commits_last_12mo = sum(
+        int(count) for key, count in commits_by_month.items() if key in recent_months
+    )
+
+    return {
+        "schema_version": 1,
+        "generated_by": f"gitstats {get_version()}",
+        "generated_at": now.astimezone().isoformat(timespec="seconds"),
+        "name": getattr(data, "project_name", "") or "",
+        "report_path": report_path,
+        "first_commit": _iso(first_stamp),
+        "last_commit": _iso(last_stamp),
+        "age_days": age_days,
+        "active_days": len(getattr(data, "active_days", set()) or set()),
+        "total_commits": int(getattr(data, "total_commits", 0) or 0),
+        "total_authors": len(authors),
+        "active_authors_12mo": active_12mo,
+        "commits_last_12mo": commits_last_12mo,
+        "total_files": int(getattr(data, "total_files", 0) or 0),
+        "total_lines": int(getattr(data, "total_lines", 0) or 0),
+        "lines_added": int(getattr(data, "total_lines_added", 0) or 0),
+        "lines_removed": int(getattr(data, "total_lines_removed", 0) or 0),
+        "total_tags": len(getattr(data, "tags", {}) or {}),
+        "era": era,
+        "top_authors": top_authors,
+        "author_commits": author_commits,
+        "commits_by_year": {
+            str(year): commits for year, commits in sorted(commits_by_year.items())
+        },
+    }
+
+
+def write_repo_summary(summary: dict[str, Any], path: str) -> None:
+    """Write ``summary.json`` into a report directory.
+
+    The filename is fixed; resolving the target and checking it stays under
+    the report root guards against directory traversal.
+    """
+    base = os.path.abspath(path)
+    target = os.path.abspath(os.path.join(base, "summary.json"))
+    if os.path.commonpath([base, target]) != base:
+        raise ValueError(f"Refusing to write outside report directory: {path}")
+    with open(target, "w", encoding="utf-8") as f:
+        json.dump(summary, f, indent=2)
+
+
+def load_repo_summaries(outputpath: str) -> list[dict[str, Any]]:
+    """Read every ``<outputpath>/*/summary.json`` back into memory.
+
+    Only immediate subdirectories that resolve inside ``outputpath`` are
+    considered, so symlinked or crafted entries cannot read outside it.
+    """
+    base = os.path.realpath(outputpath)
+    summaries = []
+    try:
+        entries = sorted(os.listdir(base))
+    except OSError:
+        return []
+    for entry in entries:
+        candidate = os.path.realpath(os.path.join(base, entry))
+        if os.path.commonpath([base, candidate]) != base or not os.path.isdir(candidate):
+            continue
+        summary_file = os.path.join(candidate, "summary.json")
+        if not os.path.isfile(summary_file):
+            continue
+        try:
+            with open(summary_file, encoding="utf-8") as f:
+                summaries.append(json.load(f))
+        except (OSError, ValueError):
+            logger.warning(f"Skipping unreadable summary: {summary_file}")
+    return summaries
+
+
+class AggregateReportCreator:
+    """Render the portfolio page for a multi-repository run."""
+
+    def create(
+        self,
+        summaries: list[dict[str, Any]],
+        failures: list[dict[str, str]],
+        path: str,
+        title: str = "GitStats Portfolio",
+    ) -> None:
+        self._copy_assets(path)
+        f = self._open_portfolio_file(path)
+        try:
+            self._write_page(f, summaries, failures, title)
+        finally:
+            f.close()
+
+    @staticmethod
+    def _copy_assets(path: str) -> None:
+        basedir = os.path.dirname(os.path.abspath(__file__))
+        for file in (
+            load_config()["style"],
+            "sortable.js",
+            "arrow-up.gif",
+            "arrow-down.gif",
+            "arrow-none.gif",
+        ):
+            src = os.path.join(basedir, file)
+            if os.path.exists(src):
+                shutil.copyfile(src, os.path.join(path, file))
+
+    @staticmethod
+    def _open_portfolio_file(path: str) -> Any:
+        """Open the portfolio index for writing, confined to the output root.
+
+        The filename is fixed; resolving the target and checking it stays
+        under the output root guards against directory traversal.
+        """
+        base = os.path.abspath(path)
+        target = os.path.abspath(os.path.join(base, "index.html"))
+        if os.path.commonpath([base, target]) != base:
+            raise ValueError(f"Refusing to write outside report directory: {path}")
+        return open(target, "w", encoding="utf-8")
+
+    def _write_page(
+        self,
+        f: Any,
+        summaries: list[dict[str, Any]],
+        failures: list[dict[str, str]],
+        title: str,
+    ) -> None:
+        self._print_header(f, title)
+        self._print_nav(f, title)
+
+        f.write(f"<h1>{html.escape(title)}</h1>")
+        generated = datetime.datetime.now().strftime("%Y-%m-%d %H:%M:%S")
+        f.write(
+            f'<p class="portfolio-subtitle">{len(summaries)} repositories &middot; '
+            f"generated by gitstats {html.escape(get_version())} on {generated}</p>"
+        )
+
+        self._write_totals(f, summaries)
+        self._write_repo_table(f, summaries)
+        self._write_failures(f, failures)
+
+        f.write(
+            '<div class="footer">'
+            '<span class="footer-generated">Generated by '
+            '<a href="https://github.com/shenxianpeng/gitstats" target="_blank" rel="noopener">gitstats</a>'
+            "</span>"
+            "</div>\n"
+        )
+        f.write("</body>\n</html>")
+
+    @staticmethod
+    def _print_header(f: Any, title: str) -> None:
+        f.write(
+            """<!DOCTYPE html>
+<html lang="en">
+<head>
+	<meta charset="UTF-8">
+	<meta name="viewport" content="width=device-width, initial-scale=1.0">
+	<title>GitStats - {}</title>
+	<!-- Apply theme before CSS loads to prevent flash of unstyled content -->
+	<script>(function(){{var t=localStorage.getItem('theme')||'light';document.documentElement.setAttribute('data-theme',t);}})();</script>
+	<link rel="stylesheet" href="{}" type="text/css">
+	<meta name="generator" content="GitStats {}">
+	<script type="text/javascript" src="sortable.js"></script>
+	<script>
+		function toggleTheme() {{
+			const currentTheme = document.documentElement.getAttribute('data-theme');
+			const newTheme = currentTheme === 'dark' ? 'light' : 'dark';
+			document.documentElement.setAttribute('data-theme', newTheme);
+			localStorage.setItem('theme', newTheme);
+			updateThemeIcon(newTheme);
+		}}
+
+		function updateThemeIcon(theme) {{
+			const button = document.getElementById('theme-toggle');
+			if (button) {{
+				button.innerHTML = theme === 'dark' ? '☀️' : '\U0001f319';
+				button.setAttribute('aria-label', theme === 'dark' ? 'Switch to light mode' : 'Switch to dark mode');
+			}}
+		}}
+
+		document.addEventListener('DOMContentLoaded', function() {{
+			updateThemeIcon(document.documentElement.getAttribute('data-theme'));
+		}});
+	</script>
+</head>
+<body>
+""".format(html.escape(title), load_config()["style"], get_version())
+        )
+
+    @staticmethod
+    def _print_nav(f: Any, title: str) -> None:
+        f.write(
+            f"""
+            <div class="nav">
+            <a href="index.html" class="nav-brand">GitStats</a>
+            <ul>
+            <li><a href="index.html">{html.escape(title)}</a></li>
+            </ul>
+            <div class="nav-right">
+            <button id="theme-toggle" class="theme-toggle" onclick="toggleTheme()" aria-label="Switch to dark mode">\U0001f319</button>
+            </div>
+            </div>
+            """
+        )
+
+    @staticmethod
+    def _write_totals(f: Any, summaries: list[dict[str, Any]]) -> None:
+        distinct_authors: set[str] = set()
+        for summary in summaries:
+            distinct_authors.update((summary.get("author_commits") or {}).keys())
+        total_commits = sum(s.get("total_commits", 0) for s in summaries)
+        total_lines = sum(s.get("total_lines", 0) for s in summaries)
+        total_tags = sum(s.get("total_tags", 0) for s in summaries)
+        last_commit = max((s.get("last_commit", "") for s in summaries), default="")
+
+        f.write("<h2>Totals</h2>")
+        f.write("<table border='1' cellspacing='0' cellpadding='4'>")
+        f.write(f"<tr><td>Repositories</td><td>{len(summaries)}</td></tr>")
+        f.write(f"<tr><td>Total Commits</td><td>{total_commits}</td></tr>")
+        f.write(f"<tr><td>Distinct Authors</td><td>{len(distinct_authors)}</td></tr>")
+        f.write(f"<tr><td>Total Lines of Code</td><td>{total_lines}</td></tr>")
+        f.write(f"<tr><td>Total Tags</td><td>{total_tags}</td></tr>")
+        f.write(f"<tr><td>Last Commit</td><td>{html.escape(last_commit)}</td></tr>")
+        f.write("</table>")
+
+    @staticmethod
+    def _write_repo_table(f: Any, summaries: list[dict[str, Any]]) -> None:
+        f.write("<h2>Repositories</h2>")
+        f.write('<table class="sortable" id="portfolio">')
+        f.write(
+            "<tr><th>Repository</th><th>Health</th><th>Commits</th><th>Authors</th>"
+            "<th>Active (12 mo)</th><th>Files</th><th>Lines</th>"
+            "<th>Last Commit</th><th>Age (days)</th></tr>"
+        )
+        ordered = sorted(summaries, key=lambda s: -s.get("total_commits", 0))
+        for summary in ordered:
+            name = html.escape(summary.get("name", ""))
+            link = html.escape(summary.get("report_path", ""), quote=True)
+            era = summary.get("era", "")
+            era_html = (
+                f'<span class="history-era history-era-{html.escape(era)}">{html.escape(era)}</span>'
+                if era
+                else ""
+            )
+            last_commit = html.escape((summary.get("last_commit", "") or "")[:10])
+            f.write(
+                f'<tr><td><a href="{link}">{name}</a></td>'
+                f"<td>{era_html}</td>"
+                f"<td>{summary.get('total_commits', 0)}</td>"
+                f"<td>{summary.get('total_authors', 0)}</td>"
+                f"<td>{summary.get('active_authors_12mo', 0)}</td>"
+                f"<td>{summary.get('total_files', 0)}</td>"
+                f"<td>{summary.get('total_lines', 0)}</td>"
+                f"<td>{last_commit}</td>"
+                f"<td>{summary.get('age_days', 0)}</td></tr>"
+            )
+        f.write("</table>")
+
+    @staticmethod
+    def _write_failures(f: Any, failures: list[dict[str, str]]) -> None:
+        if not failures:
+            return
+        f.write("<h2>Failed Repositories</h2>")
+        f.write("<table border='1' cellspacing='0' cellpadding='4'>")
+        f.write("<tr><th>Repository</th><th>Error</th></tr>")
+        for failure in failures:
+            f.write(
+                f"<tr><td>{html.escape(failure.get('name', ''))}</td>"
+                f"<td>{html.escape(failure.get('error', ''))}</td></tr>"
+            )
+        f.write("</table>")

--- a/gitstats/aggregate.py
+++ b/gitstats/aggregate.py
@@ -158,11 +158,8 @@ def load_repo_summaries(outputpath: str) -> list[dict[str, Any]]:
     except OSError:
         return []
     for entry in entries:
-        candidate = os.path.realpath(os.path.join(base, entry))
-        if os.path.commonpath([base, candidate]) != base or not os.path.isdir(candidate):
-            continue
-        summary_file = os.path.join(candidate, "summary.json")
-        if not os.path.isfile(summary_file):
+        summary_file = os.path.realpath(os.path.join(base, os.path.basename(entry), "summary.json"))
+        if os.path.commonpath([base, summary_file]) != base or not os.path.isfile(summary_file):
             continue
         try:
             with open(summary_file, encoding="utf-8") as f:

--- a/gitstats/aggregate.py
+++ b/gitstats/aggregate.py
@@ -191,7 +191,13 @@ class AggregateReportCreator:
 
     @staticmethod
     def _copy_assets(path: str) -> None:
+        """Copy the shared static assets into the output root.
+
+        Asset names are hard-coded; each destination is resolved and checked
+        to stay under the output root before writing.
+        """
         basedir = os.path.dirname(os.path.abspath(__file__))
+        base = os.path.abspath(path)
         for file in (
             load_config()["style"],
             "sortable.js",
@@ -200,8 +206,11 @@ class AggregateReportCreator:
             "arrow-none.gif",
         ):
             src = os.path.join(basedir, file)
+            target = os.path.abspath(os.path.join(base, os.path.basename(file)))
+            if os.path.commonpath([base, target]) != base:
+                raise ValueError(f"Refusing to write outside report directory: {file}")
             if os.path.exists(src):
-                shutil.copyfile(src, os.path.join(path, file))
+                shutil.copyfile(src, target)
 
     @staticmethod
     def _open_portfolio_file(path: str) -> Any:

--- a/gitstats/main.py
+++ b/gitstats/main.py
@@ -14,6 +14,12 @@ from multiprocessing import Pool
 from typing import Any
 
 from gitstats import exectime_external, load_config, time_start
+from gitstats.aggregate import (
+    AggregateReportCreator,
+    _slugify_repo,
+    compute_repo_summary,
+    write_repo_summary,
+)
 from gitstats.ai_summarizer import AISummarizer
 from gitstats.report_creator import HTMLReportCreator, get_keys_sorted_by_value_key
 from gitstats.utils import (
@@ -952,58 +958,52 @@ class GitDataCollector(DataCollector):
         return datetime.datetime.fromtimestamp(stamp).strftime("%Y-%m-%d")
 
 
-def run(gitpath, outputpath, extra_fmt=None) -> int:
-    """Run the gitstats program.
+def _run_single_repo(
+    gitpath: str,
+    outputpath: str,
+    extra_fmt: str | None = None,
+    project_name: str | None = None,
+    json_sibling: bool = True,
+) -> DataCollector:
+    """Collect, refine and render the full report for one repository.
+
     Args:
         gitpath: path to the git repository
-        outputpath: path to the output directory
-        extra_fmt: extra format
+        outputpath: directory receiving this repository's report
+        extra_fmt: extra output format ("json")
+        project_name: overrides the report's project name (multi-repo runs
+            ignore the process-global ``project_name`` config, which would
+            rename every repository identically)
+        json_sibling: write the extra JSON next to the output directory
+            (single-repo behavior) instead of inside it
     Returns:
-        0 on success, 1 on failure
+        the populated collector
     """
-    rundir = os.getcwd()
-
     try:
         os.makedirs(outputpath)
     except OSError:
         pass
 
     if not os.path.isdir(outputpath):
-        logger.error("FATAL: Output path is not a directory or does not exist")
-        return 1
+        raise RuntimeError(f"Output path is not a directory: {outputpath}")
 
     logger.info(f"Output path: {outputpath}")
     cachefile = os.path.join(outputpath, "gitstats.cache")
 
-    # Guard: multi-repository analysis is not yet supported.
-    # When multiple paths are given, stats from all repos are merged into
-    # one report with the wrong project name (last repo wins).
-    # Track: https://github.com/shenxianpeng/gitstats/issues/234
-    if len(gitpath) > 1:
-        logger.error(
-            "Multi-repository analysis is not supported. "
-            "Only the first repository will be analyzed: %s",
-            gitpath[0],
-        )
-        logger.info(
-            "Track multi-repo dashboard feature: "
-            "https://github.com/shenxianpeng/gitstats/issues/234"
-        )
-        gitpath = gitpath[:1]
-
     data = GitDataCollector()
     data.load_cache(cachefile)
 
-    for gitpath in gitpath:
-        logger.info(f"Git path: {gitpath}")
-
-        prevdir = os.getcwd()
-        os.chdir(gitpath)
-
+    logger.info(f"Git path: {gitpath}")
+    prevdir = os.getcwd()
+    os.chdir(gitpath)
+    try:
         logger.info("Collecting data...")
         data.collect(gitpath)
-
+    finally:
         os.chdir(prevdir)
+
+    if project_name is not None:
+        data.project_name = project_name
 
     logger.info("Refining data...")
     data.save_cache(cachefile)
@@ -1025,23 +1025,64 @@ def run(gitpath, outputpath, extra_fmt=None) -> int:
     else:
         data.ai_summaries = {}
 
-    os.chdir(rundir)
-
     logger.info("Generating report...")
     html_report = HTMLReportCreator()
     html_report.create(data, outputpath)
 
     if extra_fmt:
-        output_file = os.path.join(gitpath, f"{outputpath}.{extra_fmt}")
         if extra_fmt == "json":
-            import json
-
+            if json_sibling:
+                output_file = os.path.join(gitpath, f"{outputpath}.{extra_fmt}")
+            else:
+                output_file = os.path.join(outputpath, "gitstats.json")
             logger.info(f'Generating JSON file: "{output_file}"')
             with open(output_file, "w", encoding="utf-8") as file:
                 json.dump(data.__dict__, file, default=str)
         else:
-            logger.error(f"Unsupported format '{extra_fmt}'")
-            return 1
+            raise RuntimeError(f"Unsupported format '{extra_fmt}'")
+
+    return data
+
+
+def run(gitpath, outputpath, extra_fmt=None) -> int:
+    """Run the gitstats program.
+
+    With one repository path the report lands directly in ``outputpath``
+    (the historical layout). With several paths each repository gets its own
+    subdirectory plus a ``summary.json``, and an aggregate portfolio page is
+    written at ``outputpath/index.html``.
+
+    Args:
+        gitpath: list of paths to git repositories
+        outputpath: path to the output directory
+        extra_fmt: extra format
+    Returns:
+        0 if at least one repository was analyzed, 1 otherwise
+    """
+    rundir = os.getcwd()
+
+    try:
+        os.makedirs(outputpath)
+    except OSError:
+        pass
+
+    if not os.path.isdir(outputpath):
+        logger.error("FATAL: Output path is not a directory or does not exist")
+        return 1
+
+    exit_code = 0
+    try:
+        if len(gitpath) == 1:
+            try:
+                data = _run_single_repo(gitpath[0], outputpath, extra_fmt)
+            except RuntimeError as e:
+                logger.error(f"FATAL: {e}")
+                return 1
+            write_repo_summary(compute_repo_summary(data, "index.html"), outputpath)
+        else:
+            exit_code = _run_multi_repo(gitpath, outputpath, extra_fmt)
+    finally:
+        os.chdir(rundir)
 
     time_end = time.time()
     exectime_internal = time_end - time_start
@@ -1054,6 +1095,48 @@ def run(gitpath, outputpath, extra_fmt=None) -> int:
             f"To view the report, run: {python_cmd} -m http.server 8000 --bind 127.0.0.1 -d {outputpath}"
         )
 
+    return exit_code
+
+
+def _run_multi_repo(gitpaths: list, outputpath: str, extra_fmt=None) -> int:
+    """Analyze several repositories and assemble the portfolio page."""
+    summaries = []
+    failures = []
+    seen_slugs: dict[str, int] = {}
+    for path in gitpaths:
+        try:
+            slug = _slugify_repo(path)
+        except ValueError as e:
+            logger.warning(f"Skipping repository {path!r}: {e}")
+            failures.append({"name": path, "path": path, "error": str(e)})
+            continue
+        count = seen_slugs.get(slug, 0) + 1
+        seen_slugs[slug] = count
+        if count > 1:
+            slug = f"{slug}-{count}"
+        repo_outdir = os.path.join(outputpath, slug)
+        try:
+            data = _run_single_repo(
+                path,
+                repo_outdir,
+                extra_fmt,
+                project_name=slug,
+                json_sibling=False,
+            )
+        except Exception as e:
+            logger.warning(f"Skipping repository {path!r}: {e}")
+            failures.append({"name": slug, "path": path, "error": str(e)})
+            continue
+        summary = compute_repo_summary(data, f"{slug}/index.html")
+        write_repo_summary(summary, repo_outdir)
+        summaries.append(summary)
+
+    if not summaries:
+        logger.error("FATAL: No repository could be analyzed")
+        return 1
+
+    logger.info("Generating portfolio page...")
+    AggregateReportCreator().create(summaries, failures, outputpath)
     return 0
 
 
@@ -1085,7 +1168,11 @@ def get_parser() -> argparse.ArgumentParser:
         "gitpath",
         metavar="<gitpath>",
         nargs="+",
-        help="Path to the Git repository. An optional output directory may follow.",
+        help=(
+            "Path(s) to Git repositories. With two or more positional arguments, "
+            "the last one is the output directory. Multiple repositories produce "
+            "per-repository reports plus an aggregate portfolio page."
+        ),
     )
     parser.add_argument(
         "outputpath",
@@ -1206,9 +1293,7 @@ def main() -> int:
     # Handle AI CLI arguments (CLI takes precedence over config)
     _apply_ai_args(conf, args)
 
-    run(gitpath, outputpath, extra_fmt=extra_fmt)
-
-    return 0
+    return run(gitpath, outputpath, extra_fmt=extra_fmt)
 
 
 if __name__ == "__main__":

--- a/gitstats/main.py
+++ b/gitstats/main.py
@@ -958,6 +958,24 @@ class GitDataCollector(DataCollector):
         return datetime.datetime.fromtimestamp(stamp).strftime("%Y-%m-%d")
 
 
+def _prepare_output_dir(path: str) -> str:
+    """Create an output directory and return its resolved path.
+
+    The directory name is reduced to its basename, re-anchored under its
+    parent and checked to stay there before creation, so a crafted value
+    cannot escape the intended location.
+    """
+    base = os.path.dirname(os.path.abspath(path))
+    target = os.path.abspath(os.path.join(base, os.path.basename(os.path.abspath(path))))
+    if os.path.commonpath([base, target]) != base:
+        raise ValueError(f"Refusing to create output directory outside {base}")
+    try:
+        os.makedirs(target)
+    except OSError:
+        pass
+    return target
+
+
 def _run_single_repo(
     gitpath: str,
     outputpath: str,
@@ -979,11 +997,7 @@ def _run_single_repo(
     Returns:
         the populated collector
     """
-    try:
-        os.makedirs(outputpath)
-    except OSError:
-        pass
-
+    outputpath = _prepare_output_dir(outputpath)
     if not os.path.isdir(outputpath):
         raise RuntimeError(f"Output path is not a directory: {outputpath}")
 
@@ -1074,11 +1088,7 @@ def run(gitpath, outputpath, extra_fmt=None) -> int:
     """
     rundir = os.getcwd()
 
-    try:
-        os.makedirs(outputpath)
-    except OSError:
-        pass
-
+    outputpath = _prepare_output_dir(outputpath)
     if not os.path.isdir(outputpath):
         logger.error("FATAL: Output path is not a directory or does not exist")
         return 1

--- a/gitstats/main.py
+++ b/gitstats/main.py
@@ -1032,16 +1032,29 @@ def _run_single_repo(
     if extra_fmt:
         if extra_fmt == "json":
             if json_sibling:
-                output_file = os.path.join(gitpath, f"{outputpath}.{extra_fmt}")
+                sibling = os.path.join(gitpath, f"{outputpath}.{extra_fmt}")
+                _dump_json_within(os.path.dirname(sibling), os.path.basename(sibling), data)
             else:
-                output_file = os.path.join(outputpath, "gitstats.json")
-            logger.info(f'Generating JSON file: "{output_file}"')
-            with open(output_file, "w", encoding="utf-8") as file:
-                json.dump(data.__dict__, file, default=str)
+                _dump_json_within(outputpath, "gitstats.json", data)
         else:
             raise RuntimeError(f"Unsupported format '{extra_fmt}'")
 
     return data
+
+
+def _dump_json_within(directory: str, filename: str, data: DataCollector) -> None:
+    """Write the collector dump as JSON inside ``directory``.
+
+    The target is resolved from the basename only and checked to stay under
+    ``directory`` before writing, guarding against directory traversal.
+    """
+    base = os.path.abspath(directory)
+    target = os.path.abspath(os.path.join(base, os.path.basename(filename)))
+    if os.path.commonpath([base, target]) != base:
+        raise ValueError(f"Refusing to write outside output directory: {filename}")
+    logger.info(f'Generating JSON file: "{target}"')
+    with open(target, "w", encoding="utf-8") as file:
+        json.dump(data.__dict__, file, default=str)
 
 
 def run(gitpath, outputpath, extra_fmt=None) -> int:

--- a/gitstats/report_creator.py
+++ b/gitstats/report_creator.py
@@ -1429,7 +1429,7 @@ class HTMLReportCreator(ReportCreator):
 	</script>
 </head>
 <body>
-""".format(self.title, load_config()["style"], get_version)
+""".format(self.title, load_config()["style"], get_version())
         )
 
     def print_nav(self, file: Any) -> None:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -224,7 +224,8 @@ def mock_data_collector():
     data.get_last_commit_date.return_value = datetime.datetime(2023, 4, 1, 0, 0)
 
     # Active days
-    data.get_active_days.return_value = {"2023-01-01", "2023-01-15", "2023-02-01", "2023-03-10"}
+    data.active_days = {"2023-01-01", "2023-01-15", "2023-02-01", "2023-03-10"}
+    data.get_active_days.return_value = data.active_days
     data.get_longest_streak.return_value = 4
     data.longest_streak = 4
     data.get_commit_delta_days.return_value = 120

--- a/tests/test_aggregate.py
+++ b/tests/test_aggregate.py
@@ -1,0 +1,201 @@
+"""Tests for the multi-repository aggregation module."""
+
+import json
+import os
+
+import pytest
+
+from gitstats.aggregate import (
+    AggregateReportCreator,
+    _slugify_repo,
+    compute_repo_summary,
+    load_repo_summaries,
+    write_repo_summary,
+)
+
+# ── _slugify_repo ────────────────────────────────────────────────────────
+
+
+class TestSlugifyRepo:
+    def test_basename(self):
+        assert _slugify_repo("/home/user/projects/myrepo") == "myrepo"
+
+    def test_trailing_separator(self):
+        assert _slugify_repo("/home/user/projects/myrepo/") == "myrepo"
+
+    def test_trailing_dot_git(self):
+        assert _slugify_repo("/srv/git/myrepo.git") == "myrepo"
+
+    def test_unsafe_characters_replaced(self):
+        assert _slugify_repo("/tmp/my repo!") == "my-repo-"
+
+    def test_relative_path(self):
+        assert _slugify_repo("some-repo") == "some-repo"
+
+    def test_root_rejected(self):
+        with pytest.raises(ValueError):
+            _slugify_repo("/")
+
+
+# ── compute_repo_summary ─────────────────────────────────────────────────
+
+
+class TestComputeRepoSummary:
+    def test_basic_fields(self, mock_data_collector):
+        summary = compute_repo_summary(mock_data_collector, "repo/index.html")
+
+        assert summary["schema_version"] == 1
+        assert summary["report_path"] == "repo/index.html"
+        assert summary["name"] == mock_data_collector.project_name
+        assert summary["total_commits"] == mock_data_collector.total_commits
+        assert summary["total_files"] == mock_data_collector.total_files
+        assert summary["total_lines"] == mock_data_collector.total_lines
+        assert summary["total_tags"] == len(mock_data_collector.tags)
+        assert summary["first_commit"]
+        assert summary["last_commit"]
+        assert summary["age_days"] >= 1
+
+    def test_bots_excluded(self, mock_data_collector):
+        mock_data_collector.authors = {
+            "Alice": {"commits": 30, "last_commit_stamp": 1700000000},
+            "dependabot[bot]": {"commits": 99, "last_commit_stamp": 1700000000},
+        }
+        summary = compute_repo_summary(mock_data_collector, "repo/index.html")
+
+        assert summary["total_authors"] == 1
+        assert "dependabot[bot]" not in summary["author_commits"]
+        assert [a["name"] for a in summary["top_authors"]] == ["Alice"]
+
+    def test_active_authors_window(self, mock_data_collector):
+        import time
+
+        now = time.time()
+        mock_data_collector.authors = {
+            "Fresh": {"commits": 5, "last_commit_stamp": now - 86400},
+            "Stale": {"commits": 5, "last_commit_stamp": now - 400 * 86400},
+        }
+        summary = compute_repo_summary(mock_data_collector, "repo/index.html")
+
+        assert summary["active_authors_12mo"] == 1
+
+    def test_era_label_present(self, mock_data_collector):
+        mock_data_collector.commits_by_year = {2021: 10, 2022: 40, 2023: 50}
+        summary = compute_repo_summary(mock_data_collector, "repo/index.html")
+
+        assert summary["era"] != ""
+        assert list(summary["commits_by_year"]) == ["2021", "2022", "2023"]
+
+    def test_top_authors_sorted_and_capped(self, mock_data_collector):
+        mock_data_collector.authors = {
+            f"author{i}": {"commits": i, "last_commit_stamp": 0} for i in range(1, 8)
+        }
+        summary = compute_repo_summary(mock_data_collector, "repo/index.html")
+
+        assert len(summary["top_authors"]) == 5
+        assert summary["top_authors"][0] == {"name": "author7", "commits": 7}
+
+
+# ── write_repo_summary / load_repo_summaries ─────────────────────────────
+
+
+class TestSummaryIO:
+    def test_roundtrip(self, temp_dir):
+        repo_dir = os.path.join(temp_dir, "repo")
+        os.makedirs(repo_dir)
+        write_repo_summary({"schema_version": 1, "name": "repo"}, repo_dir)
+
+        with open(os.path.join(repo_dir, "summary.json"), encoding="utf-8") as f:
+            assert json.load(f)["name"] == "repo"
+
+        summaries = load_repo_summaries(temp_dir)
+        assert len(summaries) == 1
+        assert summaries[0]["name"] == "repo"
+
+    def test_load_skips_dirs_without_summary(self, temp_dir):
+        os.makedirs(os.path.join(temp_dir, "empty"))
+        assert load_repo_summaries(temp_dir) == []
+
+    def test_load_missing_root(self, temp_dir):
+        assert load_repo_summaries(os.path.join(temp_dir, "nope")) == []
+
+
+# ── AggregateReportCreator ───────────────────────────────────────────────
+
+
+def _summary(name, commits, authors_map, **overrides):
+    base = {
+        "schema_version": 1,
+        "name": name,
+        "report_path": f"{name}/index.html",
+        "first_commit": "2020-01-01 00:00:00",
+        "last_commit": "2023-06-01 00:00:00",
+        "age_days": 1200,
+        "active_days": 300,
+        "total_commits": commits,
+        "total_authors": len(authors_map),
+        "active_authors_12mo": 1,
+        "commits_last_12mo": 10,
+        "total_files": 10,
+        "total_lines": 1000,
+        "lines_added": 1500,
+        "lines_removed": 500,
+        "total_tags": 2,
+        "era": "steady",
+        "top_authors": [],
+        "author_commits": authors_map,
+        "commits_by_year": {},
+    }
+    base.update(overrides)
+    return base
+
+
+class TestAggregateReportCreator:
+    def _render(self, temp_dir, summaries, failures=()):
+        AggregateReportCreator().create(summaries, list(failures), temp_dir)
+        with open(os.path.join(temp_dir, "index.html"), encoding="utf-8") as f:
+            return f.read()
+
+    def test_page_structure(self, temp_dir):
+        html = self._render(
+            temp_dir,
+            [
+                _summary("alpha", 100, {"Alice": 60, "Bob": 40}),
+                _summary("beta", 50, {"Alice": 50}, era="dormant"),
+            ],
+        )
+
+        assert '<table class="sortable" id="portfolio">' in html
+        assert 'href="alpha/index.html"' in html
+        assert 'href="beta/index.html"' in html
+        assert "history-era-steady" in html
+        assert "history-era-dormant" in html
+        # Distinct authors = union, not the naive per-repo sum
+        assert "<tr><td>Distinct Authors</td><td>2</td></tr>" in html
+        assert "<tr><td>Total Commits</td><td>150</td></tr>" in html
+        # Sorted by commits: alpha row before beta row
+        assert html.index('href="alpha/index.html"') < html.index('href="beta/index.html"')
+
+    def test_assets_copied(self, temp_dir):
+        self._render(temp_dir, [_summary("alpha", 1, {"A": 1})])
+        assert os.path.exists(os.path.join(temp_dir, "sortable.js"))
+        assert os.path.exists(os.path.join(temp_dir, "gitstats.css"))
+        assert not os.path.exists(os.path.join(temp_dir, "chart.umd.min.js"))
+
+    def test_failures_section_escaped(self, temp_dir):
+        html = self._render(
+            temp_dir,
+            [_summary("alpha", 1, {"A": 1})],
+            failures=[{"name": "bad", "path": "/x", "error": "<script>boom</script>"}],
+        )
+
+        assert "Failed Repositories" in html
+        assert "&lt;script&gt;boom&lt;/script&gt;" in html
+        assert "<script>boom</script>" not in html
+
+    def test_no_failures_section_when_empty(self, temp_dir):
+        html = self._render(temp_dir, [_summary("alpha", 1, {"A": 1})])
+        assert "Failed Repositories" not in html
+
+    def test_repo_name_escaped(self, temp_dir):
+        html = self._render(temp_dir, [_summary("a<b>", 1, {"A": 1})])
+        assert "a&lt;b&gt;" in html

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -618,6 +618,9 @@ class TestRunIntegration:
         assert os.path.isdir(output)
         for page in ("index", "activity", "authors", "files", "lines", "tags"):
             assert os.path.exists(f"{output}/{page}.html")
+        # Single-repo mode keeps the flat layout and adds a summary.json
+        assert os.path.exists(f"{output}/summary.json")
+        assert not any(e.is_dir() for e in os.scandir(output) if e.name != ".ai_cache")
 
     def test_run_with_json(self, git_repo, temp_dir):
         """run() with extra_fmt='json' should produce a JSON file."""
@@ -639,8 +642,10 @@ class TestRunIntegration:
         json_path = f"{output}.json"
         assert os.path.exists(json_path), f"Expected {json_path} to exist"
 
-    def test_run_multi_repo_guarded(self, git_repo, git_repo_minimal, temp_dir):
-        """run() with multiple repos should warn and only process the first."""
+    def test_run_multi_repo_aggregate(self, git_repo, git_repo_minimal, temp_dir):
+        """run() with multiple repos writes per-repo reports and a portfolio page."""
+        import json
+
         import gitstats
         import gitstats.main
 
@@ -651,14 +656,71 @@ class TestRunIntegration:
         gitstats.report_creator.conf = cfg
 
         output = os.path.join(temp_dir, "report")
-        # Pass two repos – the second should be ignored with a warning
         ret = run([git_repo, git_repo_minimal], output)
 
         assert ret == 0
-        assert os.path.isdir(output)
-        # Report is generated for the first repo only
-        for page in ("index", "activity", "authors", "files", "lines", "tags"):
-            assert os.path.exists(f"{output}/{page}.html")
+        # Each repository gets a full report in its own subdirectory
+        for slug in ("git_repo", "git_repo_minimal"):
+            for page in ("index", "activity", "authors", "files", "lines", "tags"):
+                assert os.path.exists(f"{output}/{slug}/{page}.html")
+            with open(f"{output}/{slug}/summary.json", encoding="utf-8") as f:
+                summary = json.load(f)
+            assert summary["schema_version"] == 1
+            assert summary["name"] == slug
+            assert summary["report_path"] == f"{slug}/index.html"
+            assert summary["total_commits"] > 0
+
+        # Aggregate portfolio page at the output root links both repos
+        with open(f"{output}/index.html", encoding="utf-8") as f:
+            index = f.read()
+        assert 'href="git_repo/index.html"' in index
+        assert 'href="git_repo_minimal/index.html"' in index
+        assert "Totals" in index
+        # Per-repo pages must not leak into the output root
+        assert not os.path.exists(f"{output}/activity.html")
+
+    def test_run_multi_repo_tolerates_failure(self, git_repo, temp_dir):
+        """One broken repo is reported on the portfolio page, not fatal."""
+        import gitstats
+        import gitstats.main
+
+        cfg = dict(gitstats.DEFAULT_CONFIG, ai_enabled=False)
+        gitstats._config = cfg
+        gitstats.main.conf = cfg
+        gitstats.utils.conf = cfg
+        gitstats.report_creator.conf = cfg
+
+        not_a_repo = os.path.join(temp_dir, "not_a_repo")
+        os.makedirs(not_a_repo)
+        output = os.path.join(temp_dir, "report")
+        ret = run([git_repo, not_a_repo], output)
+
+        assert ret == 0
+        assert os.path.exists(f"{output}/git_repo/index.html")
+        with open(f"{output}/index.html", encoding="utf-8") as f:
+            index = f.read()
+        assert "Failed Repositories" in index
+        assert "not_a_repo" in index
+
+    def test_run_multi_repo_all_failed(self, temp_dir):
+        """run() returns 1 when no repository could be analyzed."""
+        import gitstats
+        import gitstats.main
+
+        cfg = dict(gitstats.DEFAULT_CONFIG, ai_enabled=False)
+        gitstats._config = cfg
+        gitstats.main.conf = cfg
+        gitstats.utils.conf = cfg
+        gitstats.report_creator.conf = cfg
+
+        bad_one = os.path.join(temp_dir, "bad_one")
+        bad_two = os.path.join(temp_dir, "bad_two")
+        os.makedirs(bad_one)
+        os.makedirs(bad_two)
+        output = os.path.join(temp_dir, "report")
+        ret = run([bad_one, bad_two], output)
+
+        assert ret == 1
 
 
 # ── get_parser / CLI ─────────────────────────────────────────────────────


### PR DESCRIPTION
Closes the local multi-repo half of #234.

## What this adds

Running gitstats with several repository paths now produces a full report per repository plus one **portfolio page** at the output root:

```bash
gitstats repo1 repo2 repo3 out/
```

- Each repository's complete report goes to `out/REPO/`, with its own cache and a machine-readable `out/REPO/summary.json` (`schema_version: 1` — commits, authors, active authors over the last 12 months, lines, tags, age, per-author commit counts, commits by year, and a health/era label).
- `out/index.html` is an aggregate page: a totals strip (repositories, total commits, **distinct** authors across repos, lines, tags, last commit) and a sortable table with one row per repository — health badge, commits, authors, active (12 mo), files, lines, last commit, age — each linking into the full report. The health badge reuses the same era classification as the History page.
- One broken repository doesn't abort the run: it's logged, listed in a "Failed Repositories" section on the portfolio page, and the exit code is non-zero only when *no* repository could be analyzed.

## Behavior compatibility

- **Single-repo runs are unchanged**: same flat layout, report at `out/index.html`. Verified by generating a report before and after this change on the same repo — byte-identical except timestamps. The only addition is `summary.json` (also written in single mode, so external tooling gets one stable format).
- The old behavior for multiple paths was to warn and truncate to the first repository, because a single reused collector merged stats across repos with last-repo-wins naming. Each repository now gets a fresh collector, and the working directory is restored in a `finally:` so one failed collection can't poison the next.
- In multi-repo mode the `project_name` config is ignored (it's process-global and would rename every repository identically); each report is named after its repository directory.
- `main()` now propagates `run()`'s exit code instead of always returning 0.
- Drive-by fix: the generator meta tag in page headers rendered the `get_version` function repr instead of the version string.

## Implementation notes

- New `gitstats/aggregate.py`: pure `compute_repo_summary()` (no git calls, bots excluded — same conventions as `compute_project_history`), `write_repo_summary()` / `load_repo_summaries()` with path-containment guards, and `AggregateReportCreator` reusing `gitstats.css` + `sortable.js` so the portfolio matches the per-repo pages (including the theme toggle).
- `run()` in `main.py` split into a thin orchestrator plus `_run_single_repo()` / `_run_multi_repo()`.
- Repository directory names are slugified (`[A-Za-z0-9._-]` only, collisions deduped with `-2`, `-3`).

`--org ORGNAME` (list + clone all repositories of a GitHub organization) is the planned follow-up on #234; this PR deliberately keeps v1 network-free.

## Tests

- `tests/test_aggregate.py` (19 new tests): summary computation, bot exclusion, 12-month activity window, slugification, traversal rejection, portfolio rendering (distinct-author union vs naive sum, HTML escaping, failures section).
- `tests/test_main.py`: the old truncation test is replaced by a real two-repo integration test (per-repo reports + summaries + aggregate page, no leakage into the output root), plus failure-tolerance and all-failed exit-code tests; single-repo flat-layout regression assertions added.
- Full suite: 276 passed; ruff and mypy clean.