### PR TITLE
feat: portfolio readability — activity totals, thousands separators, Since column

### DIFF
--- a/gitstats/aggregate.py
+++ b/gitstats/aggregate.py
@@ -21,7 +21,7 @@ from typing import Any
 
 from gitstats import load_config
 from gitstats.report_creator import _classify_eras
-from gitstats.utils import get_version
+from gitstats.utils import format_int, get_version
 
 logger = logging.getLogger("gitstats")
 
@@ -314,18 +314,20 @@ class AggregateReportCreator:
         for summary in summaries:
             distinct_authors.update((summary.get("author_commits") or {}).keys())
         total_commits = sum(s.get("total_commits", 0) for s in summaries)
+        commits_12mo = sum(s.get("commits_last_12mo", 0) for s in summaries)
+        active_repos = sum(1 for s in summaries if s.get("commits_last_12mo", 0) > 0)
         total_lines = sum(s.get("total_lines", 0) for s in summaries)
-        total_tags = sum(s.get("total_tags", 0) for s in summaries)
-        last_commit = max((s.get("last_commit", "") for s in summaries), default="")
 
         f.write("<h2>Totals</h2>")
         f.write("<table border='1' cellspacing='0' cellpadding='4'>")
         f.write(f"<tr><td>Repositories</td><td>{len(summaries)}</td></tr>")
-        f.write(f"<tr><td>Total Commits</td><td>{total_commits}</td></tr>")
-        f.write(f"<tr><td>Distinct Authors</td><td>{len(distinct_authors)}</td></tr>")
-        f.write(f"<tr><td>Total Lines of Code</td><td>{total_lines}</td></tr>")
-        f.write(f"<tr><td>Total Tags</td><td>{total_tags}</td></tr>")
-        f.write(f"<tr><td>Last Commit</td><td>{html.escape(last_commit)}</td></tr>")
+        f.write(f"<tr><td>Total Commits</td><td>{format_int(total_commits)}</td></tr>")
+        f.write(f"<tr><td>Commits (last 12 mo)</td><td>{format_int(commits_12mo)}</td></tr>")
+        f.write(f"<tr><td>Distinct Authors</td><td>{format_int(len(distinct_authors))}</td></tr>")
+        f.write(
+            f"<tr><td>Active Repositories (12 mo)</td><td>{active_repos} / {len(summaries)}</td></tr>"
+        )
+        f.write(f"<tr><td>Lines of Code</td><td>{format_int(total_lines)}</td></tr>")
         f.write("</table>")
 
     @staticmethod
@@ -334,8 +336,8 @@ class AggregateReportCreator:
         f.write('<table class="sortable" id="portfolio">')
         f.write(
             "<tr><th>Repository</th><th>Health</th><th>Commits</th><th>Authors</th>"
-            "<th>Active (12 mo)</th><th>Files</th><th>Lines</th>"
-            "<th>Last Commit</th><th>Age (days)</th></tr>"
+            "<th>Active (12 mo)</th><th>Files</th><th>Lines of Code</th>"
+            "<th>Last Commit</th><th>Since</th></tr>"
         )
         ordered = sorted(summaries, key=lambda s: -s.get("total_commits", 0))
         for summary in ordered:
@@ -348,16 +350,17 @@ class AggregateReportCreator:
                 else ""
             )
             last_commit = html.escape((summary.get("last_commit", "") or "")[:10])
+            since = html.escape((summary.get("first_commit", "") or "")[:4])
             f.write(
                 f'<tr><td><a href="{link}">{name}</a></td>'
                 f"<td>{era_html}</td>"
-                f"<td>{summary.get('total_commits', 0)}</td>"
-                f"<td>{summary.get('total_authors', 0)}</td>"
-                f"<td>{summary.get('active_authors_12mo', 0)}</td>"
-                f"<td>{summary.get('total_files', 0)}</td>"
-                f"<td>{summary.get('total_lines', 0)}</td>"
+                f"<td>{format_int(summary.get('total_commits', 0))}</td>"
+                f"<td>{format_int(summary.get('total_authors', 0))}</td>"
+                f"<td>{format_int(summary.get('active_authors_12mo', 0))}</td>"
+                f"<td>{format_int(summary.get('total_files', 0))}</td>"
+                f"<td>{format_int(summary.get('total_lines', 0))}</td>"
                 f"<td>{last_commit}</td>"
-                f"<td>{summary.get('age_days', 0)}</td></tr>"
+                f"<td>{since}</td></tr>"
             )
         f.write("</table>")
 

--- a/gitstats/report_creator.py
+++ b/gitstats/report_creator.py
@@ -14,6 +14,7 @@ from typing import Any
 
 from gitstats import WEEKDAYS, get_i18n_text, load_config
 from gitstats.utils import (
+    format_int,
     get_git_version,
     get_pipe_output,
     get_version,
@@ -122,16 +123,20 @@ class HTMLReportCreator(ReportCreator):
         f.write(
             f"<tr><td>Longest Streak</td><td>{data.get_longest_streak()} consecutive active days</td></tr>"
         )
-        f.write(f"<tr><td>Total Files</td><td>{data.get_total_files()}</td></tr>")
+        f.write(f"<tr><td>Total Files</td><td>{format_int(data.get_total_files())}</td></tr>")
         f.write(
-            "<tr><td>Total Lines of Code</td><td>%s (%d added, %d removed)</td></tr>"
-            % (data.get_total_loc(), data.total_lines_added, data.total_lines_removed)
+            "<tr><td>Total Lines of Code</td><td>%s (%s added, %s removed)</td></tr>"
+            % (
+                format_int(data.get_total_loc()),
+                format_int(data.total_lines_added),
+                format_int(data.total_lines_removed),
+            )
         )
         f.write(
-            f"<tr><td>Total Commits</td><td>{data.get_total_commits()} (average {float(data.get_total_commits()) / len(data.get_active_days()):.1f} commits per active day, {float(data.get_total_commits()) / data.get_commit_delta_days():.1f} per all days)</td></tr>"
+            f"<tr><td>Total Commits</td><td>{format_int(data.get_total_commits())} (average {float(data.get_total_commits()) / len(data.get_active_days()):.1f} commits per active day, {float(data.get_total_commits()) / data.get_commit_delta_days():.1f} per all days)</td></tr>"
         )
         f.write(
-            f"<tr><td>Authors</td><td>{data.get_total_authors()} (average {(1.0 * data.get_total_commits()) / data.get_total_authors():.1f} commits per author)</td></tr>"
+            f"<tr><td>Authors</td><td>{format_int(data.get_total_authors())} (average {(1.0 * data.get_total_commits()) / data.get_total_authors():.1f} commits per author)</td></tr>"
         )
         f.write("</table>")
 

--- a/gitstats/utils.py
+++ b/gitstats/utils.py
@@ -9,6 +9,7 @@ import shlex
 import subprocess
 import time
 from importlib.metadata import PackageNotFoundError, version
+from typing import Any
 
 from gitstats import ON_LINUX, exectime_external, load_config
 
@@ -39,6 +40,18 @@ def get_version() -> str:
         return version("gitstats")
     except PackageNotFoundError:
         return "dev"
+
+
+def format_int(value: Any) -> str:
+    """Render an integer with thousands separators (44025623 -> "44,025,623").
+
+    Non-numeric values are returned unchanged so callers can pass through
+    already-formatted or missing data.
+    """
+    try:
+        return f"{int(value):,}"
+    except (TypeError, ValueError):
+        return str(value)
 
 
 def get_git_version() -> str:

--- a/tests/test_aggregate.py
+++ b/tests/test_aggregate.py
@@ -172,8 +172,52 @@ class TestAggregateReportCreator:
         # Distinct authors = union, not the naive per-repo sum
         assert "<tr><td>Distinct Authors</td><td>2</td></tr>" in html
         assert "<tr><td>Total Commits</td><td>150</td></tr>" in html
+        # Activity insight rows
+        assert "<tr><td>Commits (last 12 mo)</td><td>20</td></tr>" in html
+        assert "<tr><td>Active Repositories (12 mo)</td><td>2 / 2</td></tr>" in html
+        assert "<tr><td>Lines of Code</td><td>2,000</td></tr>" in html
+        # Low-insight totals rows are gone (Last Commit remains a table column)
+        assert "<tr><td>Total Tags</td>" not in html
+        assert "<tr><td>Last Commit</td>" not in html
+        assert "<tr><td>Total Lines of Code</td>" not in html
+        # Repo table: Since column (first-commit year) replaces Age (days)
+        assert "<th>Since</th>" in html
+        assert "Age (days)" not in html
+        assert "<td>2020</td>" in html
+        assert "<th>Lines of Code</th>" in html
         # Sorted by commits: alpha row before beta row
         assert html.index('href="alpha/index.html"') < html.index('href="beta/index.html"')
+
+    def test_thousands_separators(self, temp_dir):
+        html = self._render(
+            temp_dir,
+            [
+                _summary(
+                    "mega",
+                    1234567,
+                    {"A": 1234567},
+                    total_lines=44025623,
+                    commits_last_12mo=78432,
+                )
+            ],
+        )
+
+        assert "<tr><td>Total Commits</td><td>1,234,567</td></tr>" in html
+        assert "<tr><td>Commits (last 12 mo)</td><td>78,432</td></tr>" in html
+        assert "<tr><td>Lines of Code</td><td>44,025,623</td></tr>" in html
+        assert "<td>1,234,567</td>" in html
+        assert "<td>44,025,623</td>" in html
+
+    def test_inactive_repo_counted(self, temp_dir):
+        html = self._render(
+            temp_dir,
+            [
+                _summary("alpha", 100, {"A": 100}),
+                _summary("stale", 50, {"B": 50}, commits_last_12mo=0),
+            ],
+        )
+
+        assert "<tr><td>Active Repositories (12 mo)</td><td>1 / 2</td></tr>" in html
 
     def test_assets_copied(self, temp_dir):
         self._render(temp_dir, [_summary("alpha", 1, {"A": 1})])

--- a/tests/test_report_creator.py
+++ b/tests/test_report_creator.py
@@ -341,6 +341,8 @@ def test_create_index_html(mock_data_collector, temp_dir):
     assert "Total Commits" in html
     assert "Authors" in html
     assert "</html>" in html
+    # Large counts use thousands separators (total_lines=2000, added=3000, removed=1000)
+    assert "2,000 (3,000 added, 1,000 removed)" in html
 
 
 # ── HTMLReportCreator.create_activity_html ───────────────────────────────

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -5,6 +5,7 @@ import pytest
 from gitstats.utils import (
     count_lines_in_text,
     filter_lines_by_pattern,
+    format_int,
     get_commit_range,
     get_excluded_extensions,
     get_log_range,
@@ -205,3 +206,25 @@ def test_get_log_range_with_authors():
     result = get_log_range()
     assert '--author="Alice"' in result
     assert '--author="Hui"' in result
+
+
+# ── format_int ───────────────────────────────────────────────────────────
+
+
+def test_format_int_thousands():
+    assert format_int(44025623) == "44,025,623"
+    assert format_int(1020339) == "1,020,339"
+
+
+def test_format_int_small_numbers_unchanged():
+    assert format_int(0) == "0"
+    assert format_int(999) == "999"
+
+
+def test_format_int_numeric_strings():
+    assert format_int("1234") == "1,234"
+
+
+def test_format_int_non_numeric_passthrough():
+    assert format_int("n/a") == "n/a"
+    assert format_int(None) == "None"


### PR DESCRIPTION
Display improvements based on feedback from running the gallery (#269) on real data — 10 repositories, 1M+ commits made the readability gaps obvious.

## Totals: from inventory to insight

| Before | After |
|---|---|
| Repositories | Repositories |
| Total Commits `1020339` | Total Commits `1,020,339` |
| Distinct Authors `30148` | **Commits (last 12 mo)** `78,432` |
| Total Lines of Code `44025623` | Distinct Authors `30,148` |
| Total Tags `1240` | **Active Repositories (12 mo)** `9 / 10` |
| Last Commit `2026-08-17 13:30:59` | Lines of Code `44,025,623` |

- **Removed** Total Tags (a summed tag count carries no decision value) and Last Commit (the max across repositories says little; each repository row keeps its own Last Commit).
- **Added** Commits (last 12 mo) and Active Repositories (12 mo) — the "how alive is this portfolio" numbers a lead actually scans for.

## Number formatting

All large counts get thousands separators via a new `utils.format_int` — on the portfolio page **and** the single-repository General table (Total Files / Lines of Code / Commits / Authors). The bundled sortable.js strips commas before numeric comparison (its `clean_num`), so column sorting is unaffected — verified against the numeric-detection regex.

## Repository table

- **Age (days)** → **Since** (first-commit year, e.g. `1990`): easier to read than `5902` days, pairs naturally with the Last Commit column as a time span, and sorts correctly as a plain number.
- **Lines** → **Lines of Code**, matching the Totals wording (they render the same field).

## Compatibility

`summary.json` is unchanged — `age_days`, `total_tags` and `last_commit` are still recorded for machine consumers; only the page presentation changed.

## Tests

282 passed (6 new): totals composition, removed rows, thousands-separator rendering at gallery scale (1,234,567 / 44,025,623), inactive-repository counting, Since column, `format_int` edge cases, single-repo General formatting. ruff and mypy clean.